### PR TITLE
Added DiscoverAsyncWithMake to return the make and model from the ONV…

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,7 +4,7 @@
 		<AllowUnsafeBlocks>True</AllowUnsafeBlocks>
 		<Nullable>disable</Nullable>
 		<Title>$(ProjectName)</Title>
-		<Version>0.3.0</Version>
+		<Version>0.4.1</Version>
 		<Authors>Lukas Volf</Authors>
 		<Copyright>MIT</Copyright>
 		<PackageProjectUrl>https://github.com/jimm98y/SharpOnvif</PackageProjectUrl>

--- a/src/OnvifClient/Program.cs
+++ b/src/OnvifClient/Program.cs
@@ -18,7 +18,7 @@ public static class Program
 
     static async Task MainAsync(string[] args)
     {
-        var devices = await OnvifDiscoveryClient.DiscoverAsyncWithMake();
+        var devices = await OnvifDiscoveryClient.DiscoverAsync();
 
         if (devices == null || devices.Count == 0)
         {
@@ -28,10 +28,10 @@ public static class Program
 
         foreach (var onvifDevice in devices)
         {
-            Console.WriteLine($"Found device: Make = {onvifDevice.Make}, Model = {onvifDevice.Model}");
+            Console.WriteLine($"Found device: Manufacturer = {onvifDevice.Manufacturer}, Model = {onvifDevice.Hardware}");
         }
 
-        var device = devices.FirstOrDefault(x => x.Endpoint != null && x.Endpoint.Contains("localhost"));
+        var device = devices.FirstOrDefault(x => x.Addresses.First().Contains("localhost"));
 
         if (device == null)
         {
@@ -39,7 +39,7 @@ public static class Program
         }
         else
         {
-            using (var client = new SimpleOnvifClient(device.Endpoint, "admin", "password", true))
+            using (var client = new SimpleOnvifClient(device.Addresses.First(), "admin", "password", true))
             {
                 var services = await client.GetServicesAsync(true);
                 var cameraDateTime = await client.GetSystemDateAndTimeUtcAsync();

--- a/src/OnvifClient/Program.cs
+++ b/src/OnvifClient/Program.cs
@@ -18,8 +18,20 @@ public static class Program
 
     static async Task MainAsync(string[] args)
     {
-        var devices = await OnvifDiscoveryClient.DiscoverAsync();
-        var device = devices.FirstOrDefault(x => x.Contains("localhost"));
+        var devices = await OnvifDiscoveryClient.DiscoverAsyncWithMake();
+
+        if (devices == null || devices.Count == 0)
+        {
+            Console.WriteLine("No ONVIF devices found. Please check your network connection and try again.");
+            return;
+        }
+
+        foreach (var onvifDevice in devices)
+        {
+            Console.WriteLine($"Found device: Make = {onvifDevice.Make}, Model = {onvifDevice.Model}");
+        }
+
+        var device = devices.FirstOrDefault(x => x.Endpoint != null && x.Endpoint.Contains("localhost"));
 
         if (device == null)
         {
@@ -27,7 +39,7 @@ public static class Program
         }
         else
         {
-            using (var client = new SimpleOnvifClient(device, "admin", "password", true))
+            using (var client = new SimpleOnvifClient(device.Endpoint, "admin", "password", true))
             {
                 var services = await client.GetServicesAsync(true);
                 var cameraDateTime = await client.GetSystemDateAndTimeUtcAsync();

--- a/src/OnvifService/appsettings.json
+++ b/src/OnvifService/appsettings.json
@@ -46,8 +46,10 @@
       }
     ],
     "MAC": null,
-    "Hardware": null,
+    "Manufacturer": "Lukas Volf",
+    "Hardware": "OnvifService",
     "Name": null,
-    "City": null
+    "City": null,
+    "Country": null
   }
 }

--- a/src/SharpOnvifClient/OnvifDiscoveryClient.cs
+++ b/src/SharpOnvifClient/OnvifDiscoveryClient.cs
@@ -13,16 +13,17 @@ using System.Xml.XPath;
 
 namespace SharpOnvifClient
 {
+
+    public class OnvifDiscoveryResult
+    {
+        public string Endpoint { get; set; }
+        public string Make { get; set; }
+        public string Model { get; set; }
+    }
+
+
     public static class OnvifDiscoveryClient
     {
-        private class UdpState
-        {
-            public UdpClient Client { get; set; }
-            public IPEndPoint Endpoint { get; set; }
-            public IList<string> Result { get; set; }
-            public Action<string> Callback { get; set; }
-        }
-
         public const int ONVIF_BROADCAST_TIMEOUT = 4000; // 4s timeout
         public const int ONVIF_DISCOVERY_PORT = 3702;
         public static string OnvifDiscoveryAddress = "239.255.255.250"; // only IPv4 networks are currently supported
@@ -39,8 +40,65 @@ namespace SharpOnvifClient
         /// <returns>A list of discovered devices.</returns>
         public static async Task<IList<string>> DiscoverAsync(Action<string> onDeviceDiscovered = null, int broadcastTimeout = ONVIF_BROADCAST_TIMEOUT, int broadcastPort = 0, string deviceType = "NetworkVideoTransmitter")
         {
+            var results = await DiscoverAllAsync(r => onDeviceDiscovered?.Invoke(r), broadcastTimeout, broadcastPort, deviceType);
+            return results.Select(r => r.Endpoint).ToList();
+        }
+
+        /// <summary>
+        /// Discover ONVIF devices in the local network using a given network interface.
+        /// </summary>
+        /// <param name="ipAddress">IP address of the network interface to use (IP of the host computer on the NIC you want to use for discovery).</param>
+        /// <param name="onDeviceDiscovered">Callback to be called when a new device is discovered.</param>
+        /// <param name="broadcastTimeout"><see cref="ONVIF_BROADCAST_TIMEOUT"/>.</param>
+        /// <param name="broadcastPort">Broadcast port - 0 to let the OS choose any free port.</param>
+        /// <param name="deviceType">Device type we are searching for.</param>
+        /// <returns>A list of discovered devices.</returns>
+        public static async Task<IList<string>> DiscoverAsync(string ipAddress, Action<string> onDeviceDiscovered = null, int broadcastTimeout = ONVIF_BROADCAST_TIMEOUT, int broadcastPort = 0, string deviceType = "NetworkVideoTransmitter")
+        {
+            var results = await DiscoverAllAsync(ipAddress, r => onDeviceDiscovered?.Invoke(r), broadcastTimeout, broadcastPort, deviceType);
+
+            return results.Select(r => r.Endpoint).ToList();
+        }
+
+        /// <summary>
+        /// Discover ONVIF devices in the local network on all network interfaces and return detailed information (endpoint, make, model).
+        /// </summary>
+        /// <param name="onDeviceDiscovered">Callback to be called when a new device is discovered.</param>
+        /// <param name="broadcastTimeout">Timeout for discovery in milliseconds.</param>
+        /// <param name="broadcastPort">Broadcast port - 0 to let the OS choose any free port.</param>
+        /// <param name="deviceType">Device type to search for.</param>
+        /// <returns>A list of discovered devices with endpoint, make, and model.</returns>
+        public static async Task<IList<OnvifDiscoveryResult>> DiscoverAsyncWithMake(Action<string> onDeviceDiscovered = null, int broadcastTimeout = ONVIF_BROADCAST_TIMEOUT, int broadcastPort = 0, string deviceType = "NetworkVideoTransmitter")
+        {
+            return await DiscoverAllAsync(r => onDeviceDiscovered?.Invoke(r), broadcastTimeout, broadcastPort, deviceType);
+        }
+
+        /// <summary>
+        /// Discover ONVIF devices in the local network using a given network interface.
+        /// </summary>
+        /// <param name="ipAddress">IP address of the network interface to use (IP of the host computer on the NIC you want to use for discovery).</param>
+        /// <param name="onDeviceDiscovered">Callback to be called when a new device is discovered.</param>
+        /// <param name="broadcastTimeout"><see cref="ONVIF_BROADCAST_TIMEOUT"/>.</param>
+        /// <param name="broadcastPort">Broadcast port - 0 to let the OS choose any free port.</param>
+        /// <param name="deviceType">Device type we are searching for.</param>
+        /// <returns>A list of discovered devices with make and model.</returns>
+        public static async Task<IList<OnvifDiscoveryResult>> DiscoverAsyncWithMake(string ipAddress, Action<string> onDeviceDiscovered = null, int broadcastTimeout = ONVIF_BROADCAST_TIMEOUT, int broadcastPort = 0, string deviceType = "NetworkVideoTransmitter")
+        {
+            return await DiscoverAllAsync(ipAddress, r => onDeviceDiscovered?.Invoke(r), broadcastTimeout, broadcastPort, deviceType);
+        }
+
+        /// <summary>
+        /// Internal method to discover ONVIF devices in the local network and retrieve detailed information about them.
+        /// </summary>
+        /// <param name="onDeviceDiscovered"></param>
+        /// <param name="broadcastTimeout"></param>
+        /// <param name="broadcastPort"></param>
+        /// <param name="deviceType"></param>
+        /// <returns>A list of discovered devices with make and model.</returns>
+        internal static async Task<IList<OnvifDiscoveryResult>> DiscoverAllAsync(Action<string> onDeviceDiscovered = null, int broadcastTimeout = ONVIF_BROADCAST_TIMEOUT, int broadcastPort = 0, string deviceType = "NetworkVideoTransmitter")
+        {
             NetworkInterface[] nics = NetworkInterface.GetAllNetworkInterfaces();
-            List<Task<IList<string>>> discoveryTasks = new List<Task<IList<string>>>();
+            List<Task<IList<OnvifDiscoveryResult>>> discoveryTasks = new List<Task<IList<OnvifDiscoveryResult>>>();
 
             foreach (NetworkInterface adapter in nics)
             {
@@ -58,7 +116,7 @@ namespace SharpOnvifClient
                     continue;
 
                 if (!adapter.SupportsMulticast)
-                    continue; 
+                    continue;
 
                 if (!adapter.Supports(NetworkInterfaceComponent.IPv4))
                     continue;
@@ -76,28 +134,27 @@ namespace SharpOnvifClient
                         if (ipAddrBytes[0] == 169 && ipAddrBytes[1] == 254)
                             continue; // skip link-local address
 
-                        var discoveryTask = DiscoverAsync(ua.Address.ToString(), onDeviceDiscovered, broadcastTimeout, broadcastPort, deviceType);
-                        discoveryTasks.Add(discoveryTask);  
+                        var discoveryTask = DiscoverAllAsync(ua.Address.ToString(), onDeviceDiscovered, broadcastTimeout, broadcastPort, deviceType);
+                        discoveryTasks.Add(discoveryTask);
                     }
-                }                
+                }
             }
 
             await Task.WhenAll(discoveryTasks);
 
-            return discoveryTasks.Where(x => x.IsCompleted && !x.IsFaulted && !x.IsCanceled).SelectMany(x => x.Result).Distinct().ToList();
+            return discoveryTasks.Where(x => x.IsCompleted && !x.IsFaulted && !x.IsCanceled).SelectMany(x => x.Result).GroupBy(r => r.Endpoint).Select(g => g.First()).ToList();
         }
 
-
         /// <summary>
-        /// Discover ONVIF devices in the local network.
+        /// Internal method to discover ONVIF devices on all network interfaces and retrieve detailed information about them.
         /// </summary>
-        /// <param name="ipAddress">IP address of the network interface to use (IP of the host computer on the NIC you want to use for discovery).</param>
-        /// <param name="onDeviceDiscovered">Callback to be called when a new device is discovered.</param>
-        /// <param name="broadcastTimeout"><see cref="ONVIF_BROADCAST_TIMEOUT"/>.</param>
-        /// <param name="broadcastPort">Broadcast port - 0 to let the OS choose any free port.</param>
-        /// <param name="deviceType">Device type we are searching for.</param>
-        /// <returns>A list of discovered devices.</returns>
-        public static async Task<IList<string>> DiscoverAsync(string ipAddress, Action<string> onDeviceDiscovered = null, int broadcastTimeout = ONVIF_BROADCAST_TIMEOUT, int broadcastPort = 0, string deviceType = "NetworkVideoTransmitter")
+        /// <param name="ipAddress"></param>
+        /// <param name="onDeviceDiscovered"></param>
+        /// <param name="broadcastTimeout"></param>
+        /// <param name="broadcastPort"></param>
+        /// <param name="deviceType"></param>
+        /// <returns>A list of discovered devices with make and model.</returns>
+        internal static async Task<IList<OnvifDiscoveryResult>> DiscoverAllAsync(string ipAddress, Action<string> onDeviceDiscovered = null, int broadcastTimeout = ONVIF_BROADCAST_TIMEOUT, int broadcastPort = 0, string deviceType = "NetworkVideoTransmitter")
         {
             if (ipAddress == null)
                 throw new ArgumentNullException(nameof(ipAddress));
@@ -109,7 +166,7 @@ namespace SharpOnvifClient
             "<s:Envelope xmlns:s=\"http://www.w3.org/2003/05/soap-envelope\" xmlns:a=\"http://schemas.xmlsoap.org/ws/2004/08/addressing\">\r\n" +
             "   <s:Header>\r\n" +
             "      <a:Action s:mustUnderstand=\"1\">http://schemas.xmlsoap.org/ws/2005/04/discovery/Probe</a:Action>\r\n" +
-            "      <a:MessageID>urn:uuid:" + uuid + "</a:MessageID>\r\n" + // uuid has to be unique for each request
+            "      <a:MessageID>urn:uuid:" + uuid + "</a:MessageID>\r\n" +
             "      <a:ReplyTo>\r\n" +
             "        <a:Address>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:Address>\r\n" +
             "      </a:ReplyTo>\r\n" +
@@ -122,7 +179,10 @@ namespace SharpOnvifClient
             "   </s:Body>\r\n" +
             "</s:Envelope>\r\n";
 
-            IList<string> devices = new List<string>();
+            var results = new List<OnvifDiscoveryResult>();
+            var endpoints = new HashSet<string>();
+            var cts = new CancellationTokenSource();
+
             IPEndPoint endPoint = new IPEndPoint(IPAddress.Parse(ipAddress), broadcastPort);
             IPEndPoint multicastEndpoint = new IPEndPoint(IPAddress.Parse(OnvifDiscoveryAddress), ONVIF_DISCOVERY_PORT);
 
@@ -130,23 +190,52 @@ namespace SharpOnvifClient
             {
                 using (UdpClient client = new UdpClient(endPoint))
                 {
-                    UdpState s = new UdpState
+                    void ReceiveCallback(IAsyncResult ar)
                     {
-                        Endpoint = endPoint,
-                        Client = client,
-                        Result = devices,
-                        Callback = onDeviceDiscovered
-                    };
+                        try
+                        {
+                            IPEndPoint remote = null;
+                            byte[] receiveBytes = client.EndReceive(ar, ref remote);
+                            string response = Encoding.UTF8.GetString(receiveBytes);
 
-                    client.BeginReceive(DiscoveryMessageReceived, s);
+                            var endpoint = ReadOnvifEndpoint(response);
+                            var (make, model) = ReadOnvifMakeModelFromScopes(response);
+
+                            if (!string.IsNullOrEmpty(endpoint))
+                            {
+                                lock (results)
+                                {
+                                    if (endpoints.Add(endpoint))
+                                    {
+                                        var device = new OnvifDiscoveryResult { Endpoint = endpoint, Make = make, Model = model };
+                                        results.Add(device);
+                                        onDeviceDiscovered?.Invoke(device.Endpoint);
+                                    }
+                                }
+                            }
+                            // Continue receiving
+                            if (!cts.IsCancellationRequested)
+                                client.BeginReceive(ReceiveCallback, null);
+                        }
+                        catch
+                        {
+                            // Ignore exceptions on shutdown
+                        }
+                    }
+
+                    client.BeginReceive(ReceiveCallback, null);
 
                     byte[] message = Encoding.UTF8.GetBytes(onvifDiscoveryProbe);
-                    await client.SendAsync(message, message.Count(), multicastEndpoint);
+                    await client.SendAsync(message, message.Length, multicastEndpoint);
 
-                    // make sure we do not wait forever
-                    await Task.Delay(broadcastTimeout);
+                    await Task.Delay(broadcastTimeout, cts.Token);
+                    cts.Cancel();
 
-                    return s.Result.OrderBy(x => x).ToArray();
+                    // Return a snapshot of the results
+                    lock (results)
+                    {
+                        return results.ToList();
+                    }
                 }
             }
             finally
@@ -155,41 +244,7 @@ namespace SharpOnvifClient
             }
         }
 
-        private static void DiscoveryMessageReceived(IAsyncResult result)
-        {
-            try
-            {
-                UdpClient client = ((UdpState)result.AsyncState).Client;
-                IPEndPoint endpoint = ((UdpState)result.AsyncState).Endpoint;
-                byte[] receiveBytes = client.EndReceive(result, ref endpoint);
-                string message = Encoding.UTF8.GetString(receiveBytes);
-                string host = endpoint.Address.ToString();
-                var devices = ((UdpState)result.AsyncState).Result;
-                var deviceEndpoint = ReadOnvifEndpoint(message);
-                if (deviceEndpoint != null)
-                {
-                    devices.Add(deviceEndpoint);
 
-                    var callback = ((UdpState)result.AsyncState).Callback;
-                    if (callback != null)
-                    {
-                        try
-                        {
-                            callback.Invoke(deviceEndpoint);
-                        }
-                        catch (Exception ex)
-                        {
-                            Debug.WriteLine(ex.Message);
-                        }
-                    }
-                }
-                client.BeginReceive(DiscoveryMessageReceived, result.AsyncState);
-            }
-            catch (Exception ex)
-            {
-                Debug.WriteLine(ex.Message);
-            }
-        }
 
         private static string ReadOnvifEndpoint(string message)
         {
@@ -210,6 +265,50 @@ namespace SharpOnvifClient
                     return null;
                 }
             }
+        }
+
+        private static (string Make, string Model) ReadOnvifMakeModelFromScopes(string message)
+        {
+            using (var textReader = new StringReader(message))
+            {
+                var document = new XPathDocument(textReader);
+                var navigator = document.CreateNavigator();
+
+                var scopesNode = navigator.SelectSingleNode("//*[local-name()='Scopes']/text()");
+                if (scopesNode != null)
+                {
+                    string scopes = scopesNode.Value;
+                    string make = null, model = null;
+                    foreach (var scope in scopes.Split(' '))
+                    {
+                        if (scope.StartsWith("onvif://www.onvif.org/hardware/", StringComparison.OrdinalIgnoreCase))
+                            model = scope.Substring("onvif://www.onvif.org/hardware/".Length);
+                        if (scope.StartsWith("onvif://www.onvif.org/Manufacturer/", StringComparison.OrdinalIgnoreCase))
+                            make = scope.Substring("onvif://www.onvif.org/Manufacturer/".Length);
+                        if (scope.StartsWith("onvif://www.onvif.org/name/", StringComparison.OrdinalIgnoreCase))
+                        {
+                            var nameValue = scope.Substring("onvif://www.onvif.org/name/".Length);
+                            // Only use this if Manufacturer is missing
+                            if (make == null && !string.IsNullOrEmpty(nameValue))
+                            {
+                                var parts = nameValue.Split(new[] { "%20" }, StringSplitOptions.None);
+                                if (parts.Length > 0)
+                                {
+                                    make = parts[0];
+                                    // If model is still null, try to use the rest as model
+                                    if (model == null && parts.Length > 1)
+                                        model = string.Join(" ", parts.Skip(1));
+                                }
+                            }
+                            // If model is still null, fallback to the whole name value
+                            if (model == null && !string.IsNullOrEmpty(nameValue))
+                                model = Uri.UnescapeDataString(nameValue);
+                        }
+                    }
+                    return (make, model);
+                }
+            }
+            return (null, null);
         }
     }
 }

--- a/src/SharpOnvifClient/OnvifDiscoveryResult.cs
+++ b/src/SharpOnvifClient/OnvifDiscoveryResult.cs
@@ -1,0 +1,53 @@
+﻿namespace SharpOnvifClient
+{
+    /// <summary>
+    /// Discovered device.
+    /// </summary>
+    public class OnvifDiscoveryResult
+    {
+        /// <summary>
+        /// Raw SOAP message for advanced processing.
+        /// </summary>
+        public string Raw { get; set; }
+
+        /// <summary>
+        /// Onvif addresses.
+        /// </summary>
+        public string[] Addresses { get; set; }
+
+        /// <summary>
+        /// Onvif scopes.
+        /// </summary>
+        public string[] Scopes { get; set; }
+
+        /// <summary>
+        /// Location - city.
+        /// </summary>
+        public string City { get; set; }
+
+        /// <summary>
+        /// Location - country.
+        /// </summary>
+        public string Country { get; set; }
+
+        /// <summary>
+        /// Hardware.
+        /// </summary>
+        public string Hardware { get; set; }
+
+        /// <summary>
+        /// MAC address.
+        /// </summary>
+        public string MAC { get; set; }
+
+        /// <summary>
+        /// Device manufacturer.
+        /// </summary>
+        public string Manufacturer { get; set; }
+
+        /// <summary>
+        /// Device name.
+        /// </summary>
+        public string Name { get; set; }
+    }
+}

--- a/src/SharpOnvifCommon/Discovery/Scopes.cs
+++ b/src/SharpOnvifCommon/Discovery/Scopes.cs
@@ -1,0 +1,12 @@
+﻿namespace SharpOnvifCommon.Discovery
+{
+    public static class Scopes
+    {
+        public const string MAC = "onvif://www.onvif.org/MAC/";
+        public const string Manufacturer = "onvif://www.onvif.org/manufacturer/";
+        public const string Hardware = "onvif://www.onvif.org/hardware/";
+        public const string Name = "onvif://www.onvif.org/name/";
+        public const string City = "onvif://www.onvif.org/location/city/";
+        public const string Country = "onvif://www.onvif.org/location/country/";
+    }
+}

--- a/src/SharpOnvifServer/Discovery/DiscoveryService.cs
+++ b/src/SharpOnvifServer/Discovery/DiscoveryService.cs
@@ -268,21 +268,27 @@ namespace SharpOnvifServer.Discovery
 
         private static string BuildScopes(OnvifDiscoveryOptions options)
         {
-            List<string> scopes = options.Scopes;
+            List<string> scopes = options.Scopes.ToList(); // because we are adding additional scopes here, we need a copy of the collection
             if (scopes == null)
                 return string.Empty;
 
-            if (!string.IsNullOrEmpty(options.MAC))
-                scopes.Add($"onvif://www.onvif.org/MAC/{Uri.EscapeDataString(options.MAC)}");
+            if (!string.IsNullOrEmpty(options.City))
+                scopes.Add($"{SharpOnvifCommon.Discovery.Scopes.City}{Uri.EscapeDataString(options.City)}");
+
+            if (!string.IsNullOrEmpty(options.Country))
+                scopes.Add($"{SharpOnvifCommon.Discovery.Scopes.Country}{Uri.EscapeDataString(options.Country)}");
 
             if (!string.IsNullOrEmpty(options.Hardware))
-                scopes.Add($"onvif://www.onvif.org/hardware/{Uri.EscapeDataString(options.Hardware)}");
+                scopes.Add($"{SharpOnvifCommon.Discovery.Scopes.Hardware}{Uri.EscapeDataString(options.Hardware)}");
+
+            if (!string.IsNullOrEmpty(options.MAC))
+                scopes.Add($"{SharpOnvifCommon.Discovery.Scopes.MAC}{Uri.EscapeDataString(options.MAC)}");
+
+            if (!string.IsNullOrEmpty(options.Manufacturer))
+                scopes.Add($"{SharpOnvifCommon.Discovery.Scopes.Manufacturer}{Uri.EscapeDataString(options.Manufacturer)}");
 
             if (!string.IsNullOrEmpty(options.Name))
-                scopes.Add($"onvif://www.onvif.org/name/{Uri.EscapeDataString(options.Name)}");
-
-            if (!string.IsNullOrEmpty(options.City))
-                scopes.Add($"onvif://www.onvif.org/location/city/{Uri.EscapeDataString(options.City)}");
+                scopes.Add($"{SharpOnvifCommon.Discovery.Scopes.Name}{Uri.EscapeDataString(options.Name)}");
 
             return string.Join(' ', scopes);
         }

--- a/src/SharpOnvifServer/Discovery/OnvifDiscoveryOptions.cs
+++ b/src/SharpOnvifServer/Discovery/OnvifDiscoveryOptions.cs
@@ -9,8 +9,10 @@ namespace SharpOnvifServer.Discovery
         public List<string> Scopes { get; set; }
         public List<OnvifType> Types { get; set; }
         public string MAC { get; set; }
+        public string Manufacturer { get; set; }
         public string Hardware { get; set; }
         public string Name { get; set; }
         public string City { get; set; }
+        public string Country { get; set; }
     }
 }


### PR DESCRIPTION
Many ONVIF cameras do not allow GetDeviceInformation requests without authentication but will return a Scope SOAP packet in the discovery response, which provides much of the same information. The changes in this branch will retrieve the make and model from that. (There might be more info that could be obtained from there.)

Changed version to 0.4.1.