### PR TITLE
Digest update

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,7 +3,7 @@
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<Nullable>disable</Nullable>
 		<Title>$(ProjectName)</Title>
-		<Version>0.9.5</Version>
+		<Version>0.9.6</Version>
 		<Authors>Lukas Volf</Authors>
 		<Copyright>MIT</Copyright>
 		<PackageProjectUrl>https://github.com/jimm98y/SharpOnvif</PackageProjectUrl>

--- a/src/Onvif.Client/Onvif.Client.csproj
+++ b/src/Onvif.Client/Onvif.Client.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/src/Onvif.Server/Onvif.Server.csproj
+++ b/src/Onvif.Server/Onvif.Server.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
 	<IsPackable>false</IsPackable>

--- a/src/SharpOnvif.Tests/SharpOnvif.Tests.csproj
+++ b/src/SharpOnvif.Tests/SharpOnvif.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>

--- a/src/SharpOnvifClient.AccessControl/SharpOnvifClient.AccessControl.csproj
+++ b/src/SharpOnvifClient.AccessControl/SharpOnvifClient.AccessControl.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net481;net8.0;net10.0</TargetFrameworks>
@@ -23,13 +23,13 @@
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net10.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="10.0.652802" />
 		<PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net8.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="8.1.2" />
 		<PackageReference Include="System.ServiceModel.Http" Version="8.1.2" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.4" />
 	</ItemGroup>
 
 </Project>

--- a/src/SharpOnvifClient.AccessRules/SharpOnvifClient.AccessRules.csproj
+++ b/src/SharpOnvifClient.AccessRules/SharpOnvifClient.AccessRules.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net481;net8.0;net10.0</TargetFrameworks>
@@ -27,13 +27,13 @@
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net10.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="10.0.652802" />
 		<PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net8.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="8.1.2" />
 		<PackageReference Include="System.ServiceModel.Http" Version="8.1.2" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.4" />
 	</ItemGroup>
 
 </Project>

--- a/src/SharpOnvifClient.ActionEngine/SharpOnvifClient.ActionEngine.csproj
+++ b/src/SharpOnvifClient.ActionEngine/SharpOnvifClient.ActionEngine.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net481;net8.0;net10.0</TargetFrameworks>
@@ -23,13 +23,13 @@
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net10.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="10.0.652802" />
 		<PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net8.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="8.1.2" />
 		<PackageReference Include="System.ServiceModel.Http" Version="8.1.2" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.4" />
 	</ItemGroup>
 
 </Project>

--- a/src/SharpOnvifClient.AdvancedSecurity/SharpOnvifClient.AdvancedSecurity.csproj
+++ b/src/SharpOnvifClient.AdvancedSecurity/SharpOnvifClient.AdvancedSecurity.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net481;net8.0;net10.0</TargetFrameworks>
@@ -23,13 +23,13 @@
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net10.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="10.0.652802" />
 		<PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net8.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="8.1.2" />
 		<PackageReference Include="System.ServiceModel.Http" Version="8.1.2" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.4" />
 	</ItemGroup>
 
 

--- a/src/SharpOnvifClient.Analytics/SharpOnvifClient.Analytics.csproj
+++ b/src/SharpOnvifClient.Analytics/SharpOnvifClient.Analytics.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net481;net8.0;net10.0</TargetFrameworks>
@@ -23,13 +23,13 @@
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net10.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="10.0.652802" />
 		<PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net8.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="8.1.2" />
 		<PackageReference Include="System.ServiceModel.Http" Version="8.1.2" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.4" />
 	</ItemGroup>
 
 

--- a/src/SharpOnvifClient.AppMgmt/SharpOnvifClient.AppMgmt.csproj
+++ b/src/SharpOnvifClient.AppMgmt/SharpOnvifClient.AppMgmt.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net481;net8.0;net10.0</TargetFrameworks>
@@ -23,13 +23,13 @@
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net10.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="10.0.652802" />
 		<PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net8.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="8.1.2" />
 		<PackageReference Include="System.ServiceModel.Http" Version="8.1.2" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.4" />
 	</ItemGroup>
 
 

--- a/src/SharpOnvifClient.AuthenticationBehavior/SharpOnvifClient.AuthenticationBehavior.csproj
+++ b/src/SharpOnvifClient.AuthenticationBehavior/SharpOnvifClient.AuthenticationBehavior.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net481;net8.0;net10.0</TargetFrameworks>
@@ -23,13 +23,13 @@
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net10.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="10.0.652802" />
 		<PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net8.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="8.1.2" />
 		<PackageReference Include="System.ServiceModel.Http" Version="8.1.2" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.4" />
 	</ItemGroup>
 
 

--- a/src/SharpOnvifClient.Credential/SharpOnvifClient.Credential.csproj
+++ b/src/SharpOnvifClient.Credential/SharpOnvifClient.Credential.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net481;net8.0;net10.0</TargetFrameworks>
@@ -23,13 +23,13 @@
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net10.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="10.0.652802" />
 		<PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net8.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="8.1.2" />
 		<PackageReference Include="System.ServiceModel.Http" Version="8.1.2" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.4" />
 	</ItemGroup>
 
 

--- a/src/SharpOnvifClient.DeviceIO/SharpOnvifClient.DeviceIO.csproj
+++ b/src/SharpOnvifClient.DeviceIO/SharpOnvifClient.DeviceIO.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net481;net8.0;net10.0</TargetFrameworks>
@@ -23,13 +23,13 @@
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net10.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="10.0.652802" />
 		<PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net8.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="8.1.2" />
 		<PackageReference Include="System.ServiceModel.Http" Version="8.1.2" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.4" />
 	</ItemGroup>
 
 

--- a/src/SharpOnvifClient.DeviceMgmt/SharpOnvifClient.DeviceMgmt.csproj
+++ b/src/SharpOnvifClient.DeviceMgmt/SharpOnvifClient.DeviceMgmt.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net481;net8.0;net10.0</TargetFrameworks>
@@ -23,13 +23,13 @@
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net10.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="10.0.652802" />
 		<PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net8.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="8.1.2" />
 		<PackageReference Include="System.ServiceModel.Http" Version="8.1.2" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.4" />
 	</ItemGroup>
 
 

--- a/src/SharpOnvifClient.Display/SharpOnvifClient.Display.csproj
+++ b/src/SharpOnvifClient.Display/SharpOnvifClient.Display.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net481;net8.0;net10.0</TargetFrameworks>
@@ -23,13 +23,13 @@
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net10.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="10.0.652802" />
 		<PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net8.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="8.1.2" />
 		<PackageReference Include="System.ServiceModel.Http" Version="8.1.2" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.4" />
 	</ItemGroup>
 
 

--- a/src/SharpOnvifClient.DoorControl/SharpOnvifClient.DoorControl.csproj
+++ b/src/SharpOnvifClient.DoorControl/SharpOnvifClient.DoorControl.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net481;net8.0;net10.0</TargetFrameworks>
@@ -23,13 +23,13 @@
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net10.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="10.0.652802" />
 		<PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net8.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="8.1.2" />
 		<PackageReference Include="System.ServiceModel.Http" Version="8.1.2" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.4" />
 	</ItemGroup>
 
 

--- a/src/SharpOnvifClient.Events/SharpOnvifClient.Events.csproj
+++ b/src/SharpOnvifClient.Events/SharpOnvifClient.Events.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net481;net8.0;net10.0</TargetFrameworks>
@@ -23,13 +23,13 @@
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net10.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="10.0.652802" />
 		<PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net8.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="8.1.2" />
 		<PackageReference Include="System.ServiceModel.Http" Version="8.1.2" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.4" />
 	</ItemGroup>
 
 

--- a/src/SharpOnvifClient.Imaging/SharpOnvifClient.Imaging.csproj
+++ b/src/SharpOnvifClient.Imaging/SharpOnvifClient.Imaging.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net481;net8.0;net10.0</TargetFrameworks>
@@ -23,13 +23,13 @@
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net10.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="10.0.652802" />
 		<PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net8.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="8.1.2" />
 		<PackageReference Include="System.ServiceModel.Http" Version="8.1.2" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.4" />
 	</ItemGroup>
 
 

--- a/src/SharpOnvifClient.Media/SharpOnvifClient.Media.csproj
+++ b/src/SharpOnvifClient.Media/SharpOnvifClient.Media.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
         <TargetFrameworks>net481;net8.0;net10.0</TargetFrameworks>
@@ -23,13 +23,13 @@
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net10.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="10.0.652802" />
 		<PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net8.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="8.1.2" />
 		<PackageReference Include="System.ServiceModel.Http" Version="8.1.2" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.4" />
 	</ItemGroup>
 
 

--- a/src/SharpOnvifClient.Media2/SharpOnvifClient.Media2.csproj
+++ b/src/SharpOnvifClient.Media2/SharpOnvifClient.Media2.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net481;net8.0;net10.0</TargetFrameworks>
@@ -23,13 +23,13 @@
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net10.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="10.0.652802" />
 		<PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net8.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="8.1.2" />
 		<PackageReference Include="System.ServiceModel.Http" Version="8.1.2" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.4" />
 	</ItemGroup>
 
 

--- a/src/SharpOnvifClient.PTZ/SharpOnvifClient.PTZ.csproj
+++ b/src/SharpOnvifClient.PTZ/SharpOnvifClient.PTZ.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net481;net8.0;net10.0</TargetFrameworks>
@@ -23,13 +23,13 @@
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net10.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="10.0.652802" />
 		<PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net8.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="8.1.2" />
 		<PackageReference Include="System.ServiceModel.Http" Version="8.1.2" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.4" />
 	</ItemGroup>
 
 

--- a/src/SharpOnvifClient.Provisioning/SharpOnvifClient.Provisioning.csproj
+++ b/src/SharpOnvifClient.Provisioning/SharpOnvifClient.Provisioning.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net481;net8.0;net10.0</TargetFrameworks>
@@ -23,13 +23,13 @@
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net10.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="10.0.652802" />
 		<PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net8.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="8.1.2" />
 		<PackageReference Include="System.ServiceModel.Http" Version="8.1.2" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.4" />
 	</ItemGroup>
 
 

--- a/src/SharpOnvifClient.Receiver/SharpOnvifClient.Receiver.csproj
+++ b/src/SharpOnvifClient.Receiver/SharpOnvifClient.Receiver.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net481;net8.0;net10.0</TargetFrameworks>
@@ -23,13 +23,13 @@
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net10.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="10.0.652802" />
 		<PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net8.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="8.1.2" />
 		<PackageReference Include="System.ServiceModel.Http" Version="8.1.2" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.4" />
 	</ItemGroup>
 
 

--- a/src/SharpOnvifClient.Recording/SharpOnvifClient.Recording.csproj
+++ b/src/SharpOnvifClient.Recording/SharpOnvifClient.Recording.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net481;net8.0;net10.0</TargetFrameworks>
@@ -23,13 +23,13 @@
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net10.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="10.0.652802" />
 		<PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net8.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="8.1.2" />
 		<PackageReference Include="System.ServiceModel.Http" Version="8.1.2" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.4" />
 	</ItemGroup>
 
 

--- a/src/SharpOnvifClient.Replay/SharpOnvifClient.Replay.csproj
+++ b/src/SharpOnvifClient.Replay/SharpOnvifClient.Replay.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net481;net8.0;net10.0</TargetFrameworks>
@@ -23,13 +23,13 @@
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net10.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="10.0.652802" />
 		<PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net8.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="8.1.2" />
 		<PackageReference Include="System.ServiceModel.Http" Version="8.1.2" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.4" />
 	</ItemGroup>
 
 

--- a/src/SharpOnvifClient.Schedule/SharpOnvifClient.Schedule.csproj
+++ b/src/SharpOnvifClient.Schedule/SharpOnvifClient.Schedule.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net481;net8.0;net10.0</TargetFrameworks>
@@ -23,13 +23,13 @@
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net10.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="10.0.652802" />
 		<PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net8.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="8.1.2" />
 		<PackageReference Include="System.ServiceModel.Http" Version="8.1.2" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.4" />
 	</ItemGroup>
 
 

--- a/src/SharpOnvifClient.Search/SharpOnvifClient.Search.csproj
+++ b/src/SharpOnvifClient.Search/SharpOnvifClient.Search.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net481;net8.0;net10.0</TargetFrameworks>
@@ -23,13 +23,13 @@
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net10.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="10.0.652802" />
 		<PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net8.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="8.1.2" />
 		<PackageReference Include="System.ServiceModel.Http" Version="8.1.2" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.4" />
 	</ItemGroup>
 
 

--- a/src/SharpOnvifClient.Thermal/SharpOnvifClient.Thermal.csproj
+++ b/src/SharpOnvifClient.Thermal/SharpOnvifClient.Thermal.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net481;net8.0;net10.0</TargetFrameworks>
@@ -23,13 +23,13 @@
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net10.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="10.0.652802" />
 		<PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net8.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="8.1.2" />
 		<PackageReference Include="System.ServiceModel.Http" Version="8.1.2" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.4" />
 	</ItemGroup>
 
 

--- a/src/SharpOnvifClient.Uplink/SharpOnvifClient.Uplink.csproj
+++ b/src/SharpOnvifClient.Uplink/SharpOnvifClient.Uplink.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net481;net8.0;net10.0</TargetFrameworks>
@@ -23,13 +23,13 @@
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net10.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="10.0.652802" />
 		<PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net8.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="8.1.2" />
 		<PackageReference Include="System.ServiceModel.Http" Version="8.1.2" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.4" />
 	</ItemGroup>
 
 

--- a/src/SharpOnvifClient/Security/HttpDigestProxy.cs
+++ b/src/SharpOnvifClient/Security/HttpDigestProxy.cs
@@ -22,7 +22,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
@@ -60,7 +59,7 @@ namespace SharpOnvifClient.Security
                         resultTask = targetMethod.Invoke(Target, args) as Task;
                         await resultTask.ConfigureAwait(false);
                     }
-                    catch(System.ServiceModel.Security.MessageSecurityException ex)
+                    catch (System.ServiceModel.Security.MessageSecurityException ex)
                     {
                         State.SetHeaders(ParseMessageSecurityException(ex.Message));
 
@@ -109,7 +108,7 @@ namespace SharpOnvifClient.Security
                     result = targetMethod.Invoke(Target, args);
                 }
                 return result;
-            }            
+            }
         }
 
         private IEnumerable<string> ParseMessageSecurityException(string message)
@@ -123,17 +122,25 @@ namespace SharpOnvifClient.Security
             The authentication header received from the server was 
             'Digest realm="IP Camera", qop="auth, auth-int", nonce="0000019c15330aa11b968762b51d15c40ba2f12eb2cb1ec02427a1d82440325adbff100bc3f35d74a401e5d533f271cd5e81101a", opaque="00000000", userhash=TRUE, stale="FALSE", Digest realm="IP Camera", qop="auth, auth-int", algorithm=SHA-256, nonce="0000019c15330aa11b968762b51d15c40ba2f12eb2cb1ec02427a1d82440325adbff100bc3f35d74a401e5d533f271cd5e81101a", opaque="00000000", userhash=TRUE, stale="FALSE", Digest realm="IP Camera", qop="auth, auth-int", algorithm=SHA-512-256, nonce="0000019c15330aa11b968762b51d15c40ba2f12eb2cb1ec02427a1d82440325adbff100bc3f35d74a401e5d533f271cd5e81101a", opaque="00000000", userhash=TRUE, stale="FALSE"'.
             */
-            string[] parts = message.Split('\'');
-            string wwwAuthenticateHeadersConcatenated = parts.Single(x => x.StartsWith("Digest", StringComparison.InvariantCultureIgnoreCase));
+            int digestHeaderStart = message.IndexOf("Digest", StringComparison.OrdinalIgnoreCase);
+            if (digestHeaderStart < 0)
+            {
+                throw new InvalidOperationException("The MessageSecurityException does not contain a Digest authentication header.", new FormatException(message));
+            }
+
+            int digestHeaderEnd = message.IndexOf('\'', digestHeaderStart);
+            string wwwAuthenticateHeadersConcatenated = digestHeaderEnd >= 0
+                ? message.Substring(digestHeaderStart, digestHeaderEnd - digestHeaderStart)
+                : message.Substring(digestHeaderStart);
             string[] wwwAuthenticateHeaderParts = wwwAuthenticateHeadersConcatenated.Split(new string[] { "," }, StringSplitOptions.RemoveEmptyEntries);
 
             List<string> wwwAuthenticateHeaders = new List<string>();
             StringBuilder stringBuilder = null;
             for (int i = 0; i < wwwAuthenticateHeaderParts.Length; i++)
             {
-                if(wwwAuthenticateHeaderParts[i].TrimStart().StartsWith("Digest", StringComparison.InvariantCultureIgnoreCase))
+                if (wwwAuthenticateHeaderParts[i].TrimStart().StartsWith("Digest", StringComparison.InvariantCultureIgnoreCase))
                 {
-                    if(stringBuilder != null)
+                    if (stringBuilder != null)
                     {
                         wwwAuthenticateHeaders.Add(stringBuilder.ToString());
                     }
@@ -141,7 +148,7 @@ namespace SharpOnvifClient.Security
                     stringBuilder = new StringBuilder();
                     stringBuilder.Append(wwwAuthenticateHeaderParts[i].TrimStart());
                 }
-                else if(stringBuilder != null)
+                else if (stringBuilder != null)
                 {
                     stringBuilder.Append(",");
                     stringBuilder.Append(wwwAuthenticateHeaderParts[i]);
@@ -151,7 +158,7 @@ namespace SharpOnvifClient.Security
                     Debug.WriteLine($"Error parsing MessageException text");
                 }
             }
-            if(stringBuilder != null)
+            if (stringBuilder != null)
             {
                 wwwAuthenticateHeaders.Add(stringBuilder.ToString());
             }
@@ -168,7 +175,7 @@ namespace SharpOnvifClient.Security
         {
             var proxy = Create<T, HttpDigestProxy<T>>() as HttpDigestProxy<T>;
             proxy.Target = target;
-            proxy.State = state; 
+            proxy.State = state;
             return proxy as T;
         }
 
@@ -179,7 +186,7 @@ namespace SharpOnvifClient.Security
                 if (disposing)
                 {
                     var disposableTarget = Target as IDisposable;
-                    if(disposableTarget != null)
+                    if (disposableTarget != null)
                     {
                         disposableTarget.Dispose();
                     }

--- a/src/SharpOnvifClient/SharpOnvifClient.csproj
+++ b/src/SharpOnvifClient/SharpOnvifClient.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net481;net8.0;net10.0</TargetFrameworks>

--- a/src/SharpOnvifClient/SimpleOnvifClient.cs
+++ b/src/SharpOnvifClient/SimpleOnvifClient.cs
@@ -1,4 +1,4 @@
-﻿// SharpOnvif
+// SharpOnvif
 // Copyright (C) 2026 Lukas Volf
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -127,7 +127,7 @@ namespace SharpOnvifClient
             }
         }
 
-        protected TChannel GetOrCreateClient<TChannel>(string uri, Func<string, TChannel> creator) where TChannel : class
+        public TChannel GetOrCreateClient<TChannel>(string uri, Func<string, TChannel> creator) where TChannel : class
         {
             string key = $"{typeof(TChannel)}|{uri}";
             lock (_syncRoot)

--- a/src/SharpOnvifCommon/SharpOnvifCommon.csproj
+++ b/src/SharpOnvifCommon/SharpOnvifCommon.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net481;net8.0;net10.0</TargetFrameworks>

--- a/src/SharpOnvifServer.AccessControl/SharpOnvifServer.AccessControl.csproj
+++ b/src/SharpOnvifServer.AccessControl/SharpOnvifServer.AccessControl.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>

--- a/src/SharpOnvifServer.AccessRules/SharpOnvifServer.AccessRules.csproj
+++ b/src/SharpOnvifServer.AccessRules/SharpOnvifServer.AccessRules.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>

--- a/src/SharpOnvifServer.ActionEngine/SharpOnvifServer.ActionEngine.csproj
+++ b/src/SharpOnvifServer.ActionEngine/SharpOnvifServer.ActionEngine.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>

--- a/src/SharpOnvifServer.AdvancedSecurity/SharpOnvifServer.AdvancedSecurity.csproj
+++ b/src/SharpOnvifServer.AdvancedSecurity/SharpOnvifServer.AdvancedSecurity.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>

--- a/src/SharpOnvifServer.Analytics/SharpOnvifServer.Analytics.csproj
+++ b/src/SharpOnvifServer.Analytics/SharpOnvifServer.Analytics.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
         <TargetFrameworks>net8.0;net10.0</TargetFrameworks>

--- a/src/SharpOnvifServer.AppMgmt/SharpOnvifServer.AppMgmt.csproj
+++ b/src/SharpOnvifServer.AppMgmt/SharpOnvifServer.AppMgmt.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>

--- a/src/SharpOnvifServer.AuthenticationBehavior/SharpOnvifServer.AuthenticationBehavior.csproj
+++ b/src/SharpOnvifServer.AuthenticationBehavior/SharpOnvifServer.AuthenticationBehavior.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>

--- a/src/SharpOnvifServer.Credential/SharpOnvifServer.Credential.csproj
+++ b/src/SharpOnvifServer.Credential/SharpOnvifServer.Credential.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>

--- a/src/SharpOnvifServer.DeviceIO/SharpOnvifServer.DeviceIO.csproj
+++ b/src/SharpOnvifServer.DeviceIO/SharpOnvifServer.DeviceIO.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>

--- a/src/SharpOnvifServer.DeviceMgmt/SharpOnvifServer.DeviceMgmt.csproj
+++ b/src/SharpOnvifServer.DeviceMgmt/SharpOnvifServer.DeviceMgmt.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>

--- a/src/SharpOnvifServer.Display/SharpOnvifServer.Display.csproj
+++ b/src/SharpOnvifServer.Display/SharpOnvifServer.Display.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>

--- a/src/SharpOnvifServer.DoorControl/SharpOnvifServer.DoorControl.csproj
+++ b/src/SharpOnvifServer.DoorControl/SharpOnvifServer.DoorControl.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>

--- a/src/SharpOnvifServer.Events/SharpOnvifServer.Events.csproj
+++ b/src/SharpOnvifServer.Events/SharpOnvifServer.Events.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>

--- a/src/SharpOnvifServer.Imaging/SharpOnvifServer.Imaging.csproj
+++ b/src/SharpOnvifServer.Imaging/SharpOnvifServer.Imaging.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>

--- a/src/SharpOnvifServer.Media/SharpOnvifServer.Media.csproj
+++ b/src/SharpOnvifServer.Media/SharpOnvifServer.Media.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
         <TargetFrameworks>net8.0;net10.0</TargetFrameworks>

--- a/src/SharpOnvifServer.Media2/SharpOnvifServer.Media2.csproj
+++ b/src/SharpOnvifServer.Media2/SharpOnvifServer.Media2.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>

--- a/src/SharpOnvifServer.PTZ/SharpOnvifServer.PTZ.csproj
+++ b/src/SharpOnvifServer.PTZ/SharpOnvifServer.PTZ.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>

--- a/src/SharpOnvifServer.Provisioning/SharpOnvifServer.Provisioning.csproj
+++ b/src/SharpOnvifServer.Provisioning/SharpOnvifServer.Provisioning.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>

--- a/src/SharpOnvifServer.Receiver/SharpOnvifServer.Receiver.csproj
+++ b/src/SharpOnvifServer.Receiver/SharpOnvifServer.Receiver.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>

--- a/src/SharpOnvifServer.Recording/SharpOnvifServer.Recording.csproj
+++ b/src/SharpOnvifServer.Recording/SharpOnvifServer.Recording.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>

--- a/src/SharpOnvifServer.Replay/SharpOnvifServer.Replay.csproj
+++ b/src/SharpOnvifServer.Replay/SharpOnvifServer.Replay.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>

--- a/src/SharpOnvifServer.Schedule/SharpOnvifServer.Schedule.csproj
+++ b/src/SharpOnvifServer.Schedule/SharpOnvifServer.Schedule.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>

--- a/src/SharpOnvifServer.Search/SharpOnvifServer.Search.csproj
+++ b/src/SharpOnvifServer.Search/SharpOnvifServer.Search.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>

--- a/src/SharpOnvifServer.Thermal/SharpOnvifServer.Thermal.csproj
+++ b/src/SharpOnvifServer.Thermal/SharpOnvifServer.Thermal.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>

--- a/src/SharpOnvifServer.Uplink/SharpOnvifServer.Uplink.csproj
+++ b/src/SharpOnvifServer.Uplink/SharpOnvifServer.Uplink.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>

--- a/src/SharpOnvifServer/SharpOnvifServer.csproj
+++ b/src/SharpOnvifServer/SharpOnvifServer.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>


### PR DESCRIPTION
Stop assuming that authentication headers are always enclosed in single quotes; when using Hikvision cameras, their authentication headers are enclosed in double quotes.

Here is the actual response:

HTTP 请求未经客户端身份验证方案“Anonymous”授权。从服务器收到的身份验证标头为“Digest qop="auth", realm="IP Camera(FN636)", nonce="663338373a34393137373736373ace51538fd6d7317abb7651757a8a65af", stale="FALSE"”。