### PR TITLE
Stop assuming that authentication headers are always enclosed in sing…

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,7 +3,7 @@
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<Nullable>disable</Nullable>
 		<Title>$(ProjectName)</Title>
-		<Version>0.9.5</Version>
+		<Version>0.9.6</Version>
 		<Authors>Lukas Volf</Authors>
 		<Copyright>MIT</Copyright>
 		<PackageProjectUrl>https://github.com/jimm98y/SharpOnvif</PackageProjectUrl>
@@ -30,6 +30,6 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<Microsoft_XmlSerializer_Generator>10.0.9</Microsoft_XmlSerializer_Generator>
+		<Microsoft_XmlSerializer_Generator>10.0.12</Microsoft_XmlSerializer_Generator>
 	</PropertyGroup>
 </Project>

--- a/src/Onvif.Server/Onvif.Server.csproj
+++ b/src/Onvif.Server/Onvif.Server.csproj
@@ -10,12 +10,11 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="CoreWCF.Http" Version="1.9.0" />
-    <PackageReference Include="CoreWCF.Primitives" Version="1.9.0" />
-    <PackageReference Include="CoreWCF.WebHttp" Version="1.9.0" />
+    <PackageReference Include="CoreWCF.Http" Version="1.9.1" />
+    <PackageReference Include="CoreWCF.Primitives" Version="1.9.1" />
+    <PackageReference Include="CoreWCF.WebHttp" Version="1.9.1" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\SharpOnvif.Tests\SharpOnvif.Tests.csproj" />
     <ProjectReference Include="..\SharpOnvifServer.DeviceMgmt\SharpOnvifServer.DeviceMgmt.csproj" />
     <ProjectReference Include="..\SharpOnvifServer.Events\SharpOnvifServer.Events.csproj" />
     <ProjectReference Include="..\SharpOnvifServer.Media\SharpOnvifServer.Media.csproj" />

--- a/src/SharpOnvif.Tests/HttpDigestChallengeSource.cs
+++ b/src/SharpOnvif.Tests/HttpDigestChallengeSource.cs
@@ -1,0 +1,135 @@
+﻿// SharpOnvif
+// Copyright (C) 2026 Lukas Volf
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using SharpOnvifClient.Security;
+using System;
+using System.ServiceModel;
+using System.ServiceModel.Security;
+using System.Threading.Tasks;
+
+namespace SharpOnvif.Tests
+{
+    /// <summary>
+    /// WCF does not let the client see the response of an unauthorized request, so the WwwAuthenticate
+    ///  challenge has to be recovered from the message of the
+    ///  <see cref="MessageSecurityException"/> it throws instead. The message is localized and every
+    ///  language encloses the header differently, which is what these tests cover.
+    /// </summary>
+    /// <remarks>
+    /// The formats are the "HttpAuthorizationFailed" resource of System.ServiceModel, verbatim.
+    ///  {0} is the client authentication scheme, {1} the WwwAuthenticate header(s) of the response.
+    /// </remarks>
+    public static class HttpDigestMessages
+    {
+        public const string EnUS = "The HTTP request is unauthorized with client authentication scheme '{0}'. The authentication header received from the server was '{1}'.";
+
+        /// <summary>The header is enclosed in typographic quotes.</summary>
+        public const string ZhHans = "HTTP 请求未经客户端身份验证方案“{0}”授权。从服务器收到的身份验证标头为“{1}”。";
+
+        /// <summary>The header is enclosed in double quotes, which the challenge itself is full of.</summary>
+        public const string De = "Die HTTP-Anforderung ist beim Clientauthentifizierungsschema \"{0}\" nicht autorisiert. Vom Server wurde der Authentifizierungsheader \"{1}\" empfangen.";
+
+        /// <summary>The header is not enclosed in anything at all.</summary>
+        public const string Cs = "Požadavek protokolu HTTP je neoprávněný se schématem autorizace klienta {0}. Záhlaví ověření přijaté ze serveru je {1}.";
+    }
+
+    [ServiceContract]
+    public interface IFaultingChannel
+    {
+        [OperationContract]
+        Task CallAsync();
+
+        [OperationContract]
+        Task<string> CallWithResultAsync();
+    }
+
+    /// <summary>
+    /// Stands in for a WCF channel that is answered with a challenge. The failure is reported on the
+    ///  returned task, the way WCF reports it - a synchronous throw would be wrapped in a
+    ///  <see cref="System.Reflection.TargetInvocationException"/> and never reach the proxy.
+    /// </summary>
+    public class FaultingChannel : IFaultingChannel
+    {
+        private readonly string _exceptionMessage;
+
+        /// <summary>
+        /// Number of times the channel was called, so a test can tell a retry from a rethrow.
+        /// </summary>
+        public int Calls { get; private set; }
+
+        public FaultingChannel(string exceptionMessage)
+        {
+            this._exceptionMessage = exceptionMessage;
+        }
+
+        public Task CallAsync()
+        {
+            Calls++;
+            return Task.FromException(new MessageSecurityException(_exceptionMessage));
+        }
+
+        public Task<string> CallWithResultAsync()
+        {
+            Calls++;
+            return Task.FromException<string>(new MessageSecurityException(_exceptionMessage));
+        }
+    }
+
+    public static class HttpDigestChallengeSource
+    {
+        /// <summary>
+        /// Runs a call through <see cref="HttpDigestProxy{T}"/> and returns the challenges it recovered
+        ///  from the exception, which is what the client then authenticates with.
+        /// </summary>
+        public static string[] GetChallenges(string exceptionMessage)
+        {
+            var state = new HttpDigestState();
+            GetChallenges(exceptionMessage, state);
+            return state.GetHeaders();
+        }
+
+        /// <summary>
+        /// The same, against a state that is already in use, so that a re-challenge can be tested.
+        /// </summary>
+        public static void GetChallenges(string exceptionMessage, IHttpMessageState state)
+        {
+            var channel = new FaultingChannel(exceptionMessage);
+            var proxy = HttpDigestProxy<IFaultingChannel>.CreateProxy(channel, state);
+
+            try
+            {
+                // the retry fails as well, so the exception is expected either way
+                proxy.CallAsync().GetAwaiter().GetResult();
+            }
+            catch (MessageSecurityException)
+            { }
+        }
+
+        /// <summary>
+        /// Builds the exception message a device answering with these challenges would produce.
+        /// </summary>
+        public static string CreateExceptionMessage(string format, params string[] challenges)
+        {
+            // WCF concatenates the WwwAuthenticate headers of the response into a single value
+            return string.Format(format, "Anonymous", string.Join(", ", challenges));
+        }
+    }
+}

--- a/src/SharpOnvif.Tests/SharpOnvif.Tests.csproj
+++ b/src/SharpOnvif.Tests/SharpOnvif.Tests.csproj
@@ -8,10 +8,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSTest" Version="4.2.3" />
+    <PackageReference Include="MSTest" Version="4.4.0" />
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\SharpOnvifClient\SharpOnvifClient.csproj" />
     <ProjectReference Include="..\SharpOnvifCommon\SharpOnvifCommon.csproj" />
   </ItemGroup>
 

--- a/src/SharpOnvif.Tests/TestHttpDigestChallenge.cs
+++ b/src/SharpOnvif.Tests/TestHttpDigestChallenge.cs
@@ -1,0 +1,295 @@
+﻿// SharpOnvif
+// Copyright (C) 2026 Lukas Volf
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using SharpOnvifCommon.Security;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading;
+
+namespace SharpOnvif.Tests
+{
+    /// <summary>
+    /// Recovering the WwwAuthenticate challenges from the localized message of the
+    ///  MessageSecurityException WCF throws for an unauthorized request.
+    /// </summary>
+    [TestClass]
+    public sealed class TestHttpDigestChallenge
+    {
+        private const string MD5Challenge = "Digest realm=\"IP Camera(FN636)\", qop=\"auth, auth-int\", nonce=\"abc123\", opaque=\"00000000\", userhash=TRUE, stale=\"FALSE\"";
+        private const string Sha256Challenge = "Digest realm=\"IP Camera(FN636)\", qop=\"auth, auth-int\", algorithm=SHA-256, nonce=\"abc123\", opaque=\"00000000\", userhash=TRUE, stale=FALSE";
+
+        /// <summary>
+        /// Every language System.ServiceModel ships resources for. The quoting differs per language and in
+        ///  Czech there is no quoting at all, so nothing but the challenge grammar tells where it ends.
+        /// </summary>
+        [DataRow("en-US", "The HTTP request is unauthorized with client authentication scheme '{0}'. The authentication header received from the server was '{1}'.")]
+        [DataRow("zh-Hans", "HTTP 请求未经客户端身份验证方案“{0}”授权。从服务器收到的身份验证标头为“{1}”。")]
+        [DataRow("zh-Hant", "HTTP 要求未經用戶端驗證配置 '{0}' 的授權。接收自伺服器的驗證標頭為 '{1}'。")]
+        [DataRow("ja", "この HTTP 要求は、クライアントの認証方式 '{0}' では承認されません。サーバーから受信した認証ヘッダーは '{1}' でした。")]
+        [DataRow("ru", "Запрос HTTP не разрешен для схемы аутентификации клиента \"{0}\". От сервера получен заголовок аутентификации \"{1}\".")]
+        [DataRow("de", "Die HTTP-Anforderung ist beim Clientauthentifizierungsschema \"{0}\" nicht autorisiert. Vom Server wurde der Authentifizierungsheader \"{1}\" empfangen.")]
+        [DataRow("fr", "La requête HTTP n'est pas autorisée avec un schéma d'authentification client '{0}'. L'en-tête d'authentification reçu du serveur était '{1}'.")]
+        [DataRow("tr", "HTTP isteği, istemci kimlik doğrulama düzeni '{0}' içinde yetkilendirilmemiş. Sunucudan alınan kimlik denetimi üst bilgisi: '{1}'.")]
+        [DataRow("cs", "Požadavek protokolu HTTP je neoprávněný se schématem autorizace klienta {0}. Záhlaví ověření přijaté ze serveru je {1}.")]
+        [DataRow("pl", "Żądanie protokołu HTTP nie jest autoryzowane na podstawie schematu uwierzytelniania klienta „{0}”. Nagłówek uwierzytelnienia otrzymany z serwera to „{1}”.")]
+        [DataRow("pt-BR", "A solicitação HTTP não está autorizada no esquema de autenticação de cliente '{0}'. O cabeçalho de autenticação recebido do servidor foi '{1}'.")]
+        [DataRow("it", "La richiesta HTTP non è autorizzata con lo schema di autenticazione client '{0}'. Intestazione di autenticazione ricevuta dal server: '{1}'.")]
+        [DataRow("ko", "HTTP 요청이 클라이언트 인증 구성표 '{0}'(으)로 인증되지 않습니다. 서버에서 수신한 인증 헤더가 '{1}'입니다.")]
+        [DataRow("es", "La solicitud HTTP no está autorizada con el esquema de autenticación de cliente \"{0}\". El encabezado de autenticación recibido del servidor era \"{1}\".")]
+        [TestMethod]
+        public void TestLocalizedMessage(string culture, string format)
+        {
+            string message = HttpDigestChallengeSource.CreateExceptionMessage(format, MD5Challenge, Sha256Challenge);
+            var challenges = HttpDigestChallengeSource.GetChallenges(message);
+
+            CollectionAssert.AreEqual(new[] { MD5Challenge, Sha256Challenge }, challenges, culture);
+        }
+
+        /// <summary>
+        /// The message reported for Hikvision cameras, which enclose the header in typographic quotes.
+        /// </summary>
+        [TestMethod]
+        public void TestHikvision()
+        {
+            const string challenge = "Digest qop=\"auth\", realm=\"IP Camera(FN636)\", nonce=\"663338373a34393137373736373ace51538fd6d7317abb7651757a8a65af\", stale=\"FALSE\"";
+            string message = HttpDigestChallengeSource.CreateExceptionMessage(HttpDigestMessages.ZhHans, challenge);
+
+            CollectionAssert.AreEqual(new[] { challenge }, HttpDigestChallengeSource.GetChallenges(message));
+        }
+
+        /// <summary>
+        /// A device offers one challenge per algorithm it supports, all in the same response.
+        /// </summary>
+        [DataRow(1)]
+        [DataRow(2)]
+        [DataRow(12)]
+        [TestMethod]
+        public void TestMultipleChallenges(int count)
+        {
+            var challenges = Enumerable.Range(0, count)
+                .Select(x => $"Digest realm=\"My IP Camera\", qop=\"auth, auth-int\", algorithm=SHA-256, nonce=\"n{x}\", opaque=\"o\", userhash=TRUE, stale=FALSE")
+                .ToArray();
+
+            string message = HttpDigestChallengeSource.CreateExceptionMessage(HttpDigestMessages.Cs, challenges);
+
+            CollectionAssert.AreEqual(challenges, HttpDigestChallengeSource.GetChallenges(message));
+        }
+
+        /// <summary>
+        /// Everything the server side of SharpOnvif can offer has to survive the round trip.
+        /// </summary>
+        [TestMethod]
+        public void TestGeneratedChallenges()
+        {
+            string[] algorithms = { "", "MD5", "MD5-sess", "SHA-256", "SHA-256-sess", "SHA-512-256", "SHA-512-256-sess" };
+            string[] realms = { "My IP Camera", "Camera, Hall", "Camera = 1; qop=auth" };
+            var timestamp = DateTimeOffset.UtcNow;
+            byte[] salt = HttpDigestAuthentication.CreateNonceSessionSalt();
+
+            foreach (var serialization in new[] { BinarySerializationType.Hex, BinarySerializationType.Base64 })
+            {
+                foreach (string algorithm in algorithms)
+                {
+                    foreach (string realm in realms)
+                    {
+                        foreach (bool stale in new[] { false, true })
+                        {
+                            var challenges = new List<string>
+                            {
+                                HttpDigestAuthentication.CreateWwwAuthenticateRFC2069(
+                                    "MD5", serialization, timestamp, algorithm, null, salt, realm, "00000000", stale)
+                            };
+
+                            foreach (string qop in new[] { "auth", "auth-int", "auth, auth-int" })
+                            {
+                                challenges.Add(HttpDigestAuthentication.CreateWwwAuthenticateRFC2617(
+                                    "MD5", serialization, timestamp, algorithm, null, salt, realm, "00000000", qop, stale));
+
+                                foreach (bool userhash in new[] { false, true })
+                                {
+                                    challenges.Add(HttpDigestAuthentication.CreateWwwAuthenticateRFC7616(
+                                        "MD5", serialization, timestamp, algorithm, null, salt, realm, "00000000", qop, "UTF-8", userhash, stale));
+                                }
+                            }
+
+                            foreach (string challenge in challenges)
+                            {
+                                // Czech is the format that encloses the header in nothing at all
+                                string message = HttpDigestChallengeSource.CreateExceptionMessage(HttpDigestMessages.Cs, challenge);
+                                CollectionAssert.AreEqual(new[] { challenge }, HttpDigestChallengeSource.GetChallenges(message), challenge);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        [DataRow("Digest realm=\"testrealm@host.com\", nonce=\"dcd98b7102dd2f0e8b11d0f600bfb0c093\", opaque=\"5ccc069c403ebaf9f0171e9517f40e41\"", DisplayName = "RFC 2069")]
+        [DataRow("Digest realm=\"testrealm@host.com\", qop=\"auth,auth-int\", nonce=\"dcd98b7102dd2f0e8b11d0f600bfb0c093\", opaque=\"5ccc069c403ebaf9f0171e9517f40e41\"", DisplayName = "RFC 2617")]
+        [DataRow("Digest realm=\"http-auth@example.org\", qop=\"auth, auth-int\", algorithm=SHA-256, nonce=\"7ypf/xlj9XXwfDPEoM4URrv/xwf94BcCAzFZH4GiTo0v\", opaque=\"FQhe/qaU925kfnzjCev0ciny7QMkPqMAFRtzCUYo5tdS\"", DisplayName = "RFC 7616 SHA-256")]
+        [DataRow("Digest realm=\"api@example.org\", qop=\"auth\", algorithm=SHA-512-256, nonce=\"5TsQWLVdgBdmrQ0XsxbDODV+57QdFR34I9HAbC/RVvkK\", opaque=\"HRPCssKJSGjCrkzDg8OhwpzCiGPChXYjwrI2QmXDnsOS\", charset=UTF-8, userhash=true", DisplayName = "RFC 7616 userhash")]
+        [DataRow("Digest realm=\"testrealm\", domain=\"/foo /bar/baz\", qop=\"auth\", nonce=\"abc\"", DisplayName = "domain with spaces")]
+        [DataRow("Digest realm=\"IP Camera\", qop=auth, nonce=\"abc\", stale=FALSE", DisplayName = "unquoted qop")]
+        [TestMethod]
+        public void TestRfcExamples(string challenge)
+        {
+            foreach (string format in new[] { HttpDigestMessages.EnUS, HttpDigestMessages.Cs, HttpDigestMessages.De, HttpDigestMessages.ZhHans })
+            {
+                string message = HttpDigestChallengeSource.CreateExceptionMessage(format, challenge);
+                CollectionAssert.AreEqual(new[] { challenge }, HttpDigestChallengeSource.GetChallenges(message));
+            }
+        }
+
+        /// <summary>
+        /// The text that follows the challenge must not end up in the last auth-param. When it does, the
+        ///  client reads back a "stale" it cannot recognize and reports valid credentials as invalid.
+        /// </summary>
+        [DataRow(HttpDigestMessages.EnUS)]
+        [DataRow(HttpDigestMessages.ZhHans)]
+        [DataRow(HttpDigestMessages.De)]
+        [DataRow(HttpDigestMessages.Cs)]
+        [TestMethod]
+        public void TestTrailingTextIsNotAbsorbed(string format)
+        {
+            const string challenge = "Digest realm=\"IP Camera\", qop=\"auth, auth-int\", nonce=\"abc\", stale=TRUE";
+
+            var challenges = HttpDigestChallengeSource.GetChallenges(
+                HttpDigestChallengeSource.CreateExceptionMessage(format, challenge));
+
+            CollectionAssert.AreEqual(new[] { challenge }, challenges);
+            Assert.AreEqual("TRUE", HttpDigestAuthentication.GetValueFromHeader(challenges[0], "stale", false));
+        }
+
+        /// <summary>
+        /// The client authentication scheme is named in the same message and can be called "Digest" too.
+        /// </summary>
+        [DataRow(HttpDigestMessages.EnUS)]
+        [DataRow(HttpDigestMessages.Cs)]
+        [TestMethod]
+        public void TestSchemeNamedDigestIsNotAChallenge(string format)
+        {
+            string message = string.Format(format, "Digest", MD5Challenge);
+
+            CollectionAssert.AreEqual(new[] { MD5Challenge }, HttpDigestChallengeSource.GetChallenges(message));
+        }
+
+        [DataRow("Basic realm=\"IP Camera\", Digest realm=\"IP Camera\", qop=\"auth\", nonce=\"abc\"", DisplayName = "Basic first")]
+        [DataRow("Digest realm=\"IP Camera\", qop=\"auth\", nonce=\"abc\", Basic realm=\"IP Camera\"", DisplayName = "Basic last")]
+        [TestMethod]
+        public void TestOtherSchemesAreIgnored(string header)
+        {
+            string message = HttpDigestChallengeSource.CreateExceptionMessage(HttpDigestMessages.Cs, header);
+
+            CollectionAssert.AreEqual(
+                new[] { "Digest realm=\"IP Camera\", qop=\"auth\", nonce=\"abc\"" },
+                HttpDigestChallengeSource.GetChallenges(message));
+        }
+
+        /// <summary>
+        /// A 403 is reported as a MessageSecurityException as well, but carries no challenge.
+        /// </summary>
+        [DataRow("The HTTP request was forbidden with client authentication scheme 'Anonymous'.")]
+        [DataRow("Požadavek protokolu HTTP byl zakázán se schématem autorizace klienta Anonymous.")]
+        [DataRow("The remote server returned an error: (500) Internal Server Error.")]
+        [TestMethod]
+        public void TestMessageWithoutChallenge(string message)
+        {
+            Assert.IsNull(HttpDigestChallengeSource.GetChallenges(message));
+        }
+
+        /// <summary>
+        /// The header is chosen by the device, so it is hostile input. Anything quadratic or worse here
+        ///  would not finish - .NET caps response headers at 64 KB, so 128 KB is already twice the ceiling.
+        /// </summary>
+        [TestMethod]
+        public void TestAdversarialInput()
+        {
+            const int length = 128000;
+            string[] inputs =
+            {
+                "Digest " + new string('a', length),
+                "Digest " + new string('a', length) + "=",
+                "Digest a=\"" + new string('x', length),
+                "Digest a=" + new string('"', length),
+                "Digest " + Repeat("a=b, ", length / 5),
+                "Digest " + Repeat("a=b, ", length / 5) + "”。",
+                Repeat("Digest ", length / 7),
+                Repeat("Digest a=", length / 9),
+                "Digest " + Repeat("a = , ", length / 6),
+                "Digest a=\"" + Repeat("b, c=\\\"", length / 7),
+                "Digest a" + new string(' ', length) + "=b",
+                "Digest a=b" + Repeat(" , ", length / 3),
+                HttpDigestChallengeSource.CreateExceptionMessage(HttpDigestMessages.Cs, MD5Challenge) + new string('a', length),
+            };
+
+            var stopwatch = Stopwatch.StartNew();
+            foreach (string input in inputs)
+            {
+                HttpDigestChallengeSource.GetChallenges(input);
+            }
+            stopwatch.Stop();
+
+            Assert.IsTrue(stopwatch.Elapsed.TotalSeconds < 5, $"parsing took {stopwatch.Elapsed.TotalSeconds:0.0} s");
+        }
+
+        /// <summary>
+        /// Matching the "Digest" scheme is case insensitive, which must not depend on the current culture -
+        ///  in Turkish the upper case of "i" is not "I".
+        /// </summary>
+        [DataRow("tr-TR")]
+        [DataRow("en-US")]
+        [TestMethod]
+        public void TestCultureDoesNotAffectMatching(string culture)
+        {
+            var previous = Thread.CurrentThread.CurrentCulture;
+            try
+            {
+                Thread.CurrentThread.CurrentCulture = new CultureInfo(culture);
+
+                foreach (string scheme in new[] { "Digest", "DIGEST", "digest" })
+                {
+                    string challenge = scheme + " realm=\"IP Camera\", qop=\"auth\", nonce=\"abc\"";
+                    string message = HttpDigestChallengeSource.CreateExceptionMessage(HttpDigestMessages.Cs, challenge);
+
+                    Assert.AreEqual(1, HttpDigestChallengeSource.GetChallenges(message).Length, scheme);
+                }
+            }
+            finally
+            {
+                Thread.CurrentThread.CurrentCulture = previous;
+            }
+        }
+
+        private static string Repeat(string value, int count)
+        {
+            var builder = new StringBuilder(value.Length * count);
+            for (int i = 0; i < count; i++)
+            {
+                builder.Append(value);
+            }
+            return builder.ToString();
+        }
+    }
+}

--- a/src/SharpOnvif.Tests/TestHttpDigestProxy.cs
+++ b/src/SharpOnvif.Tests/TestHttpDigestProxy.cs
@@ -1,0 +1,116 @@
+﻿// SharpOnvif
+// Copyright (C) 2026 Lukas Volf
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using SharpOnvifClient.Security;
+using System.Security.Authentication;
+using System.ServiceModel.Security;
+using System.Threading.Tasks;
+
+namespace SharpOnvif.Tests
+{
+    /// <summary>
+    /// How HttpDigestProxy reacts to the MessageSecurityException WCF throws - it has to retry the call
+    ///  once the challenge is known, and to stay out of the way when the failure was not a challenge.
+    /// </summary>
+    [TestClass]
+    public sealed class TestHttpDigestProxy
+    {
+        private const string Challenge = "Digest realm=\"IP Camera\", qop=\"auth, auth-int\", nonce=\"abc\", opaque=\"o\", stale=FALSE";
+        private const string StaleChallenge = "Digest realm=\"IP Camera\", qop=\"auth, auth-int\", nonce=\"def\", opaque=\"o\", stale=TRUE";
+        private const string Forbidden = "The HTTP request was forbidden with client authentication scheme 'Anonymous'.";
+
+        private static IFaultingChannel CreateProxy(string exceptionMessage, out FaultingChannel channel, out HttpDigestState state)
+        {
+            channel = new FaultingChannel(exceptionMessage);
+            state = new HttpDigestState();
+            return HttpDigestProxy<IFaultingChannel>.CreateProxy(channel, state);
+        }
+
+        [DataRow(false, DisplayName = "Task")]
+        [DataRow(true, DisplayName = "Task<T>")]
+        [TestMethod]
+        public async Task TestRetryAfterChallenge(bool withResult)
+        {
+            string message = HttpDigestChallengeSource.CreateExceptionMessage(HttpDigestMessages.Cs, Challenge);
+            var proxy = CreateProxy(message, out var channel, out var state);
+
+            // the retry fails as well because the channel always faults
+            await Assert.ThrowsExactlyAsync<MessageSecurityException>(
+                () => withResult ? proxy.CallWithResultAsync() : proxy.CallAsync());
+
+            Assert.AreEqual(2, channel.Calls, "the call has to be retried once the challenge is known");
+            CollectionAssert.AreEqual(new[] { Challenge }, state.GetHeaders());
+        }
+
+        /// <summary>
+        /// A 403 is reported as a MessageSecurityException too. There is nothing to retry, and the original
+        ///  error has to reach the caller instead of being replaced by a parsing failure.
+        /// </summary>
+        [DataRow(false, DisplayName = "Task")]
+        [DataRow(true, DisplayName = "Task<T>")]
+        [TestMethod]
+        public async Task TestRethrowWithoutChallenge(bool withResult)
+        {
+            var proxy = CreateProxy(Forbidden, out var channel, out var state);
+
+            var exception = await Assert.ThrowsExactlyAsync<MessageSecurityException>(
+                () => withResult ? proxy.CallWithResultAsync() : proxy.CallAsync());
+
+            Assert.AreEqual(Forbidden, exception.Message);
+            Assert.AreEqual(1, channel.Calls, "there is no challenge, so there is nothing to retry");
+            Assert.IsNull(state.GetHeaders());
+        }
+
+        /// <summary>
+        /// The nonce expires after a while and the device answers with stale=TRUE, which is a request to
+        ///  authenticate again rather than a rejection of the credentials.
+        /// </summary>
+        [TestMethod]
+        public void TestStaleChallengeIsAccepted()
+        {
+            var state = new HttpDigestState();
+
+            HttpDigestChallengeSource.GetChallenges(
+                HttpDigestChallengeSource.CreateExceptionMessage(HttpDigestMessages.Cs, Challenge), state);
+
+            HttpDigestChallengeSource.GetChallenges(
+                HttpDigestChallengeSource.CreateExceptionMessage(HttpDigestMessages.ZhHans, StaleChallenge), state);
+
+            CollectionAssert.AreEqual(new[] { StaleChallenge }, state.GetHeaders());
+        }
+
+        /// <summary>
+        /// A challenge that is repeated without stale=TRUE means the credentials were not accepted.
+        /// </summary>
+        [TestMethod]
+        public void TestRepeatedChallengeIsRejected()
+        {
+            var state = new HttpDigestState();
+
+            HttpDigestChallengeSource.GetChallenges(
+                HttpDigestChallengeSource.CreateExceptionMessage(HttpDigestMessages.Cs, Challenge), state);
+
+            Assert.ThrowsExactly<InvalidCredentialException>(() =>
+                HttpDigestChallengeSource.GetChallenges(
+                    HttpDigestChallengeSource.CreateExceptionMessage(HttpDigestMessages.Cs, Challenge), state));
+        }
+    }
+}

--- a/src/SharpOnvifClient.AccessControl/SharpOnvifClient.AccessControl.csproj
+++ b/src/SharpOnvifClient.AccessControl/SharpOnvifClient.AccessControl.csproj
@@ -23,13 +23,13 @@
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net10.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="10.0.652802" />
 		<PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.12" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net8.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="8.1.2" />
 		<PackageReference Include="System.ServiceModel.Http" Version="8.1.2" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.4" />
 	</ItemGroup>
 
 </Project>

--- a/src/SharpOnvifClient.AccessRules/SharpOnvifClient.AccessRules.csproj
+++ b/src/SharpOnvifClient.AccessRules/SharpOnvifClient.AccessRules.csproj
@@ -27,13 +27,13 @@
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net10.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="10.0.652802" />
 		<PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.12" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net8.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="8.1.2" />
 		<PackageReference Include="System.ServiceModel.Http" Version="8.1.2" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.4" />
 	</ItemGroup>
 
 </Project>

--- a/src/SharpOnvifClient.ActionEngine/SharpOnvifClient.ActionEngine.csproj
+++ b/src/SharpOnvifClient.ActionEngine/SharpOnvifClient.ActionEngine.csproj
@@ -23,13 +23,13 @@
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net10.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="10.0.652802" />
 		<PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.12" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net8.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="8.1.2" />
 		<PackageReference Include="System.ServiceModel.Http" Version="8.1.2" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.4" />
 	</ItemGroup>
 
 </Project>

--- a/src/SharpOnvifClient.AdvancedSecurity/SharpOnvifClient.AdvancedSecurity.csproj
+++ b/src/SharpOnvifClient.AdvancedSecurity/SharpOnvifClient.AdvancedSecurity.csproj
@@ -23,13 +23,13 @@
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net10.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="10.0.652802" />
 		<PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.12" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net8.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="8.1.2" />
 		<PackageReference Include="System.ServiceModel.Http" Version="8.1.2" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.4" />
 	</ItemGroup>
 
 

--- a/src/SharpOnvifClient.Analytics/SharpOnvifClient.Analytics.csproj
+++ b/src/SharpOnvifClient.Analytics/SharpOnvifClient.Analytics.csproj
@@ -23,13 +23,13 @@
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net10.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="10.0.652802" />
 		<PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.12" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net8.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="8.1.2" />
 		<PackageReference Include="System.ServiceModel.Http" Version="8.1.2" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.4" />
 	</ItemGroup>
 
 

--- a/src/SharpOnvifClient.AppMgmt/SharpOnvifClient.AppMgmt.csproj
+++ b/src/SharpOnvifClient.AppMgmt/SharpOnvifClient.AppMgmt.csproj
@@ -23,13 +23,13 @@
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net10.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="10.0.652802" />
 		<PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.12" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net8.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="8.1.2" />
 		<PackageReference Include="System.ServiceModel.Http" Version="8.1.2" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.4" />
 	</ItemGroup>
 
 

--- a/src/SharpOnvifClient.AuthenticationBehavior/SharpOnvifClient.AuthenticationBehavior.csproj
+++ b/src/SharpOnvifClient.AuthenticationBehavior/SharpOnvifClient.AuthenticationBehavior.csproj
@@ -23,13 +23,13 @@
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net10.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="10.0.652802" />
 		<PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.12" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net8.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="8.1.2" />
 		<PackageReference Include="System.ServiceModel.Http" Version="8.1.2" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.4" />
 	</ItemGroup>
 
 

--- a/src/SharpOnvifClient.Credential/SharpOnvifClient.Credential.csproj
+++ b/src/SharpOnvifClient.Credential/SharpOnvifClient.Credential.csproj
@@ -23,13 +23,13 @@
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net10.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="10.0.652802" />
 		<PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.12" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net8.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="8.1.2" />
 		<PackageReference Include="System.ServiceModel.Http" Version="8.1.2" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.4" />
 	</ItemGroup>
 
 

--- a/src/SharpOnvifClient.DeviceIO/SharpOnvifClient.DeviceIO.csproj
+++ b/src/SharpOnvifClient.DeviceIO/SharpOnvifClient.DeviceIO.csproj
@@ -23,13 +23,13 @@
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net10.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="10.0.652802" />
 		<PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.12" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net8.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="8.1.2" />
 		<PackageReference Include="System.ServiceModel.Http" Version="8.1.2" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.4" />
 	</ItemGroup>
 
 

--- a/src/SharpOnvifClient.DeviceMgmt/SharpOnvifClient.DeviceMgmt.csproj
+++ b/src/SharpOnvifClient.DeviceMgmt/SharpOnvifClient.DeviceMgmt.csproj
@@ -23,13 +23,13 @@
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net10.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="10.0.652802" />
 		<PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.12" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net8.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="8.1.2" />
 		<PackageReference Include="System.ServiceModel.Http" Version="8.1.2" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.4" />
 	</ItemGroup>
 
 

--- a/src/SharpOnvifClient.Display/SharpOnvifClient.Display.csproj
+++ b/src/SharpOnvifClient.Display/SharpOnvifClient.Display.csproj
@@ -23,13 +23,13 @@
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net10.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="10.0.652802" />
 		<PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.12" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net8.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="8.1.2" />
 		<PackageReference Include="System.ServiceModel.Http" Version="8.1.2" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.4" />
 	</ItemGroup>
 
 

--- a/src/SharpOnvifClient.DoorControl/SharpOnvifClient.DoorControl.csproj
+++ b/src/SharpOnvifClient.DoorControl/SharpOnvifClient.DoorControl.csproj
@@ -23,13 +23,13 @@
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net10.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="10.0.652802" />
 		<PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.12" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net8.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="8.1.2" />
 		<PackageReference Include="System.ServiceModel.Http" Version="8.1.2" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.4" />
 	</ItemGroup>
 
 

--- a/src/SharpOnvifClient.Events/SharpOnvifClient.Events.csproj
+++ b/src/SharpOnvifClient.Events/SharpOnvifClient.Events.csproj
@@ -23,13 +23,13 @@
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net10.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="10.0.652802" />
 		<PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.12" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net8.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="8.1.2" />
 		<PackageReference Include="System.ServiceModel.Http" Version="8.1.2" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.4" />
 	</ItemGroup>
 
 

--- a/src/SharpOnvifClient.Imaging/SharpOnvifClient.Imaging.csproj
+++ b/src/SharpOnvifClient.Imaging/SharpOnvifClient.Imaging.csproj
@@ -23,13 +23,13 @@
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net10.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="10.0.652802" />
 		<PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.12" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net8.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="8.1.2" />
 		<PackageReference Include="System.ServiceModel.Http" Version="8.1.2" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.4" />
 	</ItemGroup>
 
 

--- a/src/SharpOnvifClient.Media/SharpOnvifClient.Media.csproj
+++ b/src/SharpOnvifClient.Media/SharpOnvifClient.Media.csproj
@@ -23,13 +23,13 @@
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net10.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="10.0.652802" />
 		<PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.12" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net8.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="8.1.2" />
 		<PackageReference Include="System.ServiceModel.Http" Version="8.1.2" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.4" />
 	</ItemGroup>
 
 

--- a/src/SharpOnvifClient.Media2/SharpOnvifClient.Media2.csproj
+++ b/src/SharpOnvifClient.Media2/SharpOnvifClient.Media2.csproj
@@ -23,13 +23,13 @@
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net10.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="10.0.652802" />
 		<PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.12" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net8.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="8.1.2" />
 		<PackageReference Include="System.ServiceModel.Http" Version="8.1.2" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.4" />
 	</ItemGroup>
 
 

--- a/src/SharpOnvifClient.PTZ/SharpOnvifClient.PTZ.csproj
+++ b/src/SharpOnvifClient.PTZ/SharpOnvifClient.PTZ.csproj
@@ -23,13 +23,13 @@
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net10.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="10.0.652802" />
 		<PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.12" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net8.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="8.1.2" />
 		<PackageReference Include="System.ServiceModel.Http" Version="8.1.2" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.4" />
 	</ItemGroup>
 
 

--- a/src/SharpOnvifClient.Provisioning/SharpOnvifClient.Provisioning.csproj
+++ b/src/SharpOnvifClient.Provisioning/SharpOnvifClient.Provisioning.csproj
@@ -23,13 +23,13 @@
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net10.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="10.0.652802" />
 		<PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.12" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net8.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="8.1.2" />
 		<PackageReference Include="System.ServiceModel.Http" Version="8.1.2" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.4" />
 	</ItemGroup>
 
 

--- a/src/SharpOnvifClient.Receiver/SharpOnvifClient.Receiver.csproj
+++ b/src/SharpOnvifClient.Receiver/SharpOnvifClient.Receiver.csproj
@@ -23,13 +23,13 @@
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net10.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="10.0.652802" />
 		<PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.12" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net8.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="8.1.2" />
 		<PackageReference Include="System.ServiceModel.Http" Version="8.1.2" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.4" />
 	</ItemGroup>
 
 

--- a/src/SharpOnvifClient.Recording/SharpOnvifClient.Recording.csproj
+++ b/src/SharpOnvifClient.Recording/SharpOnvifClient.Recording.csproj
@@ -23,13 +23,13 @@
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net10.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="10.0.652802" />
 		<PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.12" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net8.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="8.1.2" />
 		<PackageReference Include="System.ServiceModel.Http" Version="8.1.2" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.4" />
 	</ItemGroup>
 
 

--- a/src/SharpOnvifClient.Replay/SharpOnvifClient.Replay.csproj
+++ b/src/SharpOnvifClient.Replay/SharpOnvifClient.Replay.csproj
@@ -23,13 +23,13 @@
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net10.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="10.0.652802" />
 		<PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.12" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net8.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="8.1.2" />
 		<PackageReference Include="System.ServiceModel.Http" Version="8.1.2" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.4" />
 	</ItemGroup>
 
 

--- a/src/SharpOnvifClient.Schedule/SharpOnvifClient.Schedule.csproj
+++ b/src/SharpOnvifClient.Schedule/SharpOnvifClient.Schedule.csproj
@@ -23,13 +23,13 @@
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net10.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="10.0.652802" />
 		<PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.12" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net8.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="8.1.2" />
 		<PackageReference Include="System.ServiceModel.Http" Version="8.1.2" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.4" />
 	</ItemGroup>
 
 

--- a/src/SharpOnvifClient.Search/SharpOnvifClient.Search.csproj
+++ b/src/SharpOnvifClient.Search/SharpOnvifClient.Search.csproj
@@ -23,13 +23,13 @@
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net10.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="10.0.652802" />
 		<PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.12" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net8.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="8.1.2" />
 		<PackageReference Include="System.ServiceModel.Http" Version="8.1.2" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.4" />
 	</ItemGroup>
 
 

--- a/src/SharpOnvifClient.Thermal/SharpOnvifClient.Thermal.csproj
+++ b/src/SharpOnvifClient.Thermal/SharpOnvifClient.Thermal.csproj
@@ -23,13 +23,13 @@
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net10.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="10.0.652802" />
 		<PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.12" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net8.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="8.1.2" />
 		<PackageReference Include="System.ServiceModel.Http" Version="8.1.2" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.4" />
 	</ItemGroup>
 
 

--- a/src/SharpOnvifClient.Uplink/SharpOnvifClient.Uplink.csproj
+++ b/src/SharpOnvifClient.Uplink/SharpOnvifClient.Uplink.csproj
@@ -23,13 +23,13 @@
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net10.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="10.0.652802" />
 		<PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.12" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net8.')) ">
 		<PackageReference Include="System.ServiceModel.Primitives" Version="8.1.2" />
 		<PackageReference Include="System.ServiceModel.Http" Version="8.1.2" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.4" />
 	</ItemGroup>
 
 

--- a/src/SharpOnvifClient/Security/HttpDigestProxy.cs
+++ b/src/SharpOnvifClient/Security/HttpDigestProxy.cs
@@ -22,7 +22,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
@@ -60,7 +59,7 @@ namespace SharpOnvifClient.Security
                         resultTask = targetMethod.Invoke(Target, args) as Task;
                         await resultTask.ConfigureAwait(false);
                     }
-                    catch(System.ServiceModel.Security.MessageSecurityException ex)
+                    catch (System.ServiceModel.Security.MessageSecurityException ex)
                     {
                         State.SetHeaders(ParseMessageSecurityException(ex.Message));
 
@@ -109,7 +108,7 @@ namespace SharpOnvifClient.Security
                     result = targetMethod.Invoke(Target, args);
                 }
                 return result;
-            }            
+            }
         }
 
         private IEnumerable<string> ParseMessageSecurityException(string message)
@@ -123,17 +122,25 @@ namespace SharpOnvifClient.Security
             The authentication header received from the server was 
             'Digest realm="IP Camera", qop="auth, auth-int", nonce="0000019c15330aa11b968762b51d15c40ba2f12eb2cb1ec02427a1d82440325adbff100bc3f35d74a401e5d533f271cd5e81101a", opaque="00000000", userhash=TRUE, stale="FALSE", Digest realm="IP Camera", qop="auth, auth-int", algorithm=SHA-256, nonce="0000019c15330aa11b968762b51d15c40ba2f12eb2cb1ec02427a1d82440325adbff100bc3f35d74a401e5d533f271cd5e81101a", opaque="00000000", userhash=TRUE, stale="FALSE", Digest realm="IP Camera", qop="auth, auth-int", algorithm=SHA-512-256, nonce="0000019c15330aa11b968762b51d15c40ba2f12eb2cb1ec02427a1d82440325adbff100bc3f35d74a401e5d533f271cd5e81101a", opaque="00000000", userhash=TRUE, stale="FALSE"'.
             */
-            string[] parts = message.Split('\'');
-            string wwwAuthenticateHeadersConcatenated = parts.Single(x => x.StartsWith("Digest", StringComparison.InvariantCultureIgnoreCase));
+            int digestHeaderStart = message.IndexOf("Digest", StringComparison.OrdinalIgnoreCase);
+            if (digestHeaderStart < 0)
+            {
+                throw new InvalidOperationException("The MessageSecurityException does not contain a Digest authentication header.", new FormatException(message));
+            }
+
+            int digestHeaderEnd = message.IndexOf('\'', digestHeaderStart);
+            string wwwAuthenticateHeadersConcatenated = digestHeaderEnd >= 0
+                ? message.Substring(digestHeaderStart, digestHeaderEnd - digestHeaderStart)
+                : message.Substring(digestHeaderStart);
             string[] wwwAuthenticateHeaderParts = wwwAuthenticateHeadersConcatenated.Split(new string[] { "," }, StringSplitOptions.RemoveEmptyEntries);
 
             List<string> wwwAuthenticateHeaders = new List<string>();
             StringBuilder stringBuilder = null;
             for (int i = 0; i < wwwAuthenticateHeaderParts.Length; i++)
             {
-                if(wwwAuthenticateHeaderParts[i].TrimStart().StartsWith("Digest", StringComparison.InvariantCultureIgnoreCase))
+                if (wwwAuthenticateHeaderParts[i].TrimStart().StartsWith("Digest", StringComparison.InvariantCultureIgnoreCase))
                 {
-                    if(stringBuilder != null)
+                    if (stringBuilder != null)
                     {
                         wwwAuthenticateHeaders.Add(stringBuilder.ToString());
                     }
@@ -141,7 +148,7 @@ namespace SharpOnvifClient.Security
                     stringBuilder = new StringBuilder();
                     stringBuilder.Append(wwwAuthenticateHeaderParts[i].TrimStart());
                 }
-                else if(stringBuilder != null)
+                else if (stringBuilder != null)
                 {
                     stringBuilder.Append(",");
                     stringBuilder.Append(wwwAuthenticateHeaderParts[i]);
@@ -151,7 +158,7 @@ namespace SharpOnvifClient.Security
                     Debug.WriteLine($"Error parsing MessageException text");
                 }
             }
-            if(stringBuilder != null)
+            if (stringBuilder != null)
             {
                 wwwAuthenticateHeaders.Add(stringBuilder.ToString());
             }
@@ -168,7 +175,7 @@ namespace SharpOnvifClient.Security
         {
             var proxy = Create<T, HttpDigestProxy<T>>() as HttpDigestProxy<T>;
             proxy.Target = target;
-            proxy.State = state; 
+            proxy.State = state;
             return proxy as T;
         }
 
@@ -179,7 +186,7 @@ namespace SharpOnvifClient.Security
                 if (disposing)
                 {
                     var disposableTarget = Target as IDisposable;
-                    if(disposableTarget != null)
+                    if (disposableTarget != null)
                     {
                         disposableTarget.Dispose();
                     }

--- a/src/SharpOnvifClient/Security/HttpDigestProxy.cs
+++ b/src/SharpOnvifClient/Security/HttpDigestProxy.cs
@@ -22,8 +22,9 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Reflection;
-using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 namespace SharpOnvifClient.Security
@@ -61,7 +62,11 @@ namespace SharpOnvifClient.Security
                     }
                     catch (System.ServiceModel.Security.MessageSecurityException ex)
                     {
-                        State.SetHeaders(ParseMessageSecurityException(ex.Message));
+                        IEnumerable<string> wwwAuthenticateHeaders = ParseMessageSecurityException(ex.Message);
+                        if (!wwwAuthenticateHeaders.Any())
+                            throw; // the request failed for another reason, report the original error
+
+                        State.SetHeaders(wwwAuthenticateHeaders);
 
                         resultTask = targetMethod.Invoke(Target, args) as Task;
                         await resultTask.ConfigureAwait(false);
@@ -81,7 +86,11 @@ namespace SharpOnvifClient.Security
                     }
                     catch (System.ServiceModel.Security.MessageSecurityException ex)
                     {
-                        State.SetHeaders(ParseMessageSecurityException(ex.Message));
+                        IEnumerable<string> wwwAuthenticateHeaders = ParseMessageSecurityException(ex.Message);
+                        if (!wwwAuthenticateHeaders.Any())
+                            throw; // the request failed for another reason, report the original error
+
+                        State.SetHeaders(wwwAuthenticateHeaders);
 
                         resultTask = targetMethod.Invoke(Target, args) as Task;
                         await resultTask.ConfigureAwait(false);
@@ -103,7 +112,11 @@ namespace SharpOnvifClient.Security
                 }
                 catch (System.ServiceModel.Security.MessageSecurityException ex)
                 {
-                    State.SetHeaders(ParseMessageSecurityException(ex.Message));
+                    IEnumerable<string> wwwAuthenticateHeaders = ParseMessageSecurityException(ex.Message);
+                    if (!wwwAuthenticateHeaders.Any())
+                        throw; // the request failed for another reason, report the original error
+
+                    State.SetHeaders(wwwAuthenticateHeaders);
 
                     result = targetMethod.Invoke(Target, args);
                 }
@@ -111,56 +124,59 @@ namespace SharpOnvifClient.Security
             }
         }
 
+        /// <summary>
+        /// RFC 7235 auth-param: a token, followed by either a quoted-string or another token.
+        /// The token is deliberately narrower than the RFC 7230 one, which also allows characters such as
+        ///  the apostrophe and the dot. Those are the characters the exception message ends with, and an
+        ///  unquoted value would swallow them together with the rest of the sentence. Every value an Onvif
+        ///  device sends unquoted (algorithm, qop, stale, userhash, charset, nc) fits in this set.
+        /// </summary>
+        private const string AUTH_PARAM = @"[\w-]+\s*=\s*(?:""[^""]*""|[\w-]+)";
+
+        /// <summary>
+        /// A "Digest" challenge and the comma separated list of its auth-params. Several challenges can
+        ///  follow each other, which is why the list stops at anything that is not an auth-param.
+        /// </summary>
+        private static readonly Regex _digestChallengeRegex = new Regex(
+            $@"(?<!\w)Digest\s+(?<param>{AUTH_PARAM})(?:\s*,\s*(?<param>{AUTH_PARAM}))*",
+            RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+
+        /// <returns>
+        /// The WwwAuthenticate headers, or an empty array when the message carries no Digest challenge -
+        ///  MessageSecurityException is also what WCF throws for a 403, where there is nothing to retry.
+        /// </returns>
         private IEnumerable<string> ParseMessageSecurityException(string message)
         {
             // Workaround: The only way to get the response WwwAuthenticate headers from WCF seems to be
             //  by parsing them from the Exception message text. This is not ideal and we have to be careful
             //  to not use any hardcoded strings as the exception message might be localized.
+            // The message quotes the header differently in every language - with apostrophes, with double
+            //  quotes (which the challenge itself is full of), with typographic quotes, and in some
+            //  languages it is not quoted at all. The quoting is therefore ignored and the challenges are
+            //  matched by their own grammar instead, which is what separates them from the text around them.
 
-            /*            
-            The HTTP request is unauthorized with client authentication scheme 'Anonymous'. 
-            The authentication header received from the server was 
+            /*
+            The HTTP request is unauthorized with client authentication scheme 'Anonymous'.
+            The authentication header received from the server was
             'Digest realm="IP Camera", qop="auth, auth-int", nonce="0000019c15330aa11b968762b51d15c40ba2f12eb2cb1ec02427a1d82440325adbff100bc3f35d74a401e5d533f271cd5e81101a", opaque="00000000", userhash=TRUE, stale="FALSE", Digest realm="IP Camera", qop="auth, auth-int", algorithm=SHA-256, nonce="0000019c15330aa11b968762b51d15c40ba2f12eb2cb1ec02427a1d82440325adbff100bc3f35d74a401e5d533f271cd5e81101a", opaque="00000000", userhash=TRUE, stale="FALSE", Digest realm="IP Camera", qop="auth, auth-int", algorithm=SHA-512-256, nonce="0000019c15330aa11b968762b51d15c40ba2f12eb2cb1ec02427a1d82440325adbff100bc3f35d74a401e5d533f271cd5e81101a", opaque="00000000", userhash=TRUE, stale="FALSE"'.
+
+            Hikvision, Chinese Windows - the header is enclosed in typographic quotes:
+            HTTP 请求未经客户端身份验证方案“Anonymous”授权。从服务器收到的身份验证标头为“Digest qop="auth", realm="IP Camera(FN636)", nonce="663338373a34393137373736373ace51538fd6d7317abb7651757a8a65af", stale="FALSE"”。
+
+            Czech Windows - the header is not enclosed in anything:
+            Požadavek protokolu HTTP je neoprávněný se schématem autorizace klienta Anonymous. Záhlaví ověření přijaté ze serveru je Digest realm="IP Camera", qop="auth, auth-int", nonce="0000019c15330aa11b968762b51d15c40ba2f12eb2cb1ec02427a1d82440325adbff100bc3f35d74a401e5d533f271cd5e81101a", opaque="00000000", userhash=TRUE, stale="FALSE".
             */
-            int digestHeaderStart = message.IndexOf("Digest", StringComparison.OrdinalIgnoreCase);
-            if (digestHeaderStart < 0)
-            {
-                throw new InvalidOperationException("The MessageSecurityException does not contain a Digest authentication header.", new FormatException(message));
-            }
-
-            int digestHeaderEnd = message.IndexOf('\'', digestHeaderStart);
-            string wwwAuthenticateHeadersConcatenated = digestHeaderEnd >= 0
-                ? message.Substring(digestHeaderStart, digestHeaderEnd - digestHeaderStart)
-                : message.Substring(digestHeaderStart);
-            string[] wwwAuthenticateHeaderParts = wwwAuthenticateHeadersConcatenated.Split(new string[] { "," }, StringSplitOptions.RemoveEmptyEntries);
-
             List<string> wwwAuthenticateHeaders = new List<string>();
-            StringBuilder stringBuilder = null;
-            for (int i = 0; i < wwwAuthenticateHeaderParts.Length; i++)
-            {
-                if (wwwAuthenticateHeaderParts[i].TrimStart().StartsWith("Digest", StringComparison.InvariantCultureIgnoreCase))
-                {
-                    if (stringBuilder != null)
-                    {
-                        wwwAuthenticateHeaders.Add(stringBuilder.ToString());
-                    }
 
-                    stringBuilder = new StringBuilder();
-                    stringBuilder.Append(wwwAuthenticateHeaderParts[i].TrimStart());
-                }
-                else if (stringBuilder != null)
-                {
-                    stringBuilder.Append(",");
-                    stringBuilder.Append(wwwAuthenticateHeaderParts[i]);
-                }
-                else
-                {
-                    Debug.WriteLine($"Error parsing MessageException text");
-                }
-            }
-            if (stringBuilder != null)
+            foreach (Match match in _digestChallengeRegex.Matches(message))
             {
-                wwwAuthenticateHeaders.Add(stringBuilder.ToString());
+                var authParams = match.Groups["param"].Captures.Cast<Capture>().Select(x => x.Value);
+                wwwAuthenticateHeaders.Add($"Digest {string.Join(", ", authParams)}");
+            }
+
+            if (wwwAuthenticateHeaders.Count == 0)
+            {
+                Debug.WriteLine($"No WWW-Authenticate Digest challenge was found in: {message}");
             }
 
             return wwwAuthenticateHeaders;

--- a/src/SharpOnvifCommon/SharpOnvifCommon.csproj
+++ b/src/SharpOnvifCommon/SharpOnvifCommon.csproj
@@ -20,6 +20,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="System.Runtime.Caching" Version="10.0.9" />
+		<PackageReference Include="System.Runtime.Caching" Version="10.0.12" />
 	</ItemGroup>
 </Project>

--- a/src/SharpOnvifServer.AccessControl/SharpOnvifServer.AccessControl.csproj
+++ b/src/SharpOnvifServer.AccessControl/SharpOnvifServer.AccessControl.csproj
@@ -16,8 +16,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.XmlSerializer.Generator" Version="$(Microsoft_XmlSerializer_Generator)" />
-		<PackageReference Include="CoreWCF.Http" Version="1.9.0" />
-		<PackageReference Include="CoreWCF.Primitives" Version="1.9.0" />
+		<PackageReference Include="CoreWCF.Http" Version="1.9.1" />
+		<PackageReference Include="CoreWCF.Primitives" Version="1.9.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SharpOnvifServer.AccessRules/SharpOnvifServer.AccessRules.csproj
+++ b/src/SharpOnvifServer.AccessRules/SharpOnvifServer.AccessRules.csproj
@@ -16,8 +16,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.XmlSerializer.Generator" Version="$(Microsoft_XmlSerializer_Generator)" />
-		<PackageReference Include="CoreWCF.Http" Version="1.9.0" />
-		<PackageReference Include="CoreWCF.Primitives" Version="1.9.0" />
+		<PackageReference Include="CoreWCF.Http" Version="1.9.1" />
+		<PackageReference Include="CoreWCF.Primitives" Version="1.9.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SharpOnvifServer.ActionEngine/SharpOnvifServer.ActionEngine.csproj
+++ b/src/SharpOnvifServer.ActionEngine/SharpOnvifServer.ActionEngine.csproj
@@ -16,8 +16,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.XmlSerializer.Generator" Version="$(Microsoft_XmlSerializer_Generator)" />
-		<PackageReference Include="CoreWCF.Http" Version="1.9.0" />
-		<PackageReference Include="CoreWCF.Primitives" Version="1.9.0" />
+		<PackageReference Include="CoreWCF.Http" Version="1.9.1" />
+		<PackageReference Include="CoreWCF.Primitives" Version="1.9.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SharpOnvifServer.AdvancedSecurity/SharpOnvifServer.AdvancedSecurity.csproj
+++ b/src/SharpOnvifServer.AdvancedSecurity/SharpOnvifServer.AdvancedSecurity.csproj
@@ -16,8 +16,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.XmlSerializer.Generator" Version="$(Microsoft_XmlSerializer_Generator)" />
-		<PackageReference Include="CoreWCF.Http" Version="1.9.0" />
-		<PackageReference Include="CoreWCF.Primitives" Version="1.9.0" />
+		<PackageReference Include="CoreWCF.Http" Version="1.9.1" />
+		<PackageReference Include="CoreWCF.Primitives" Version="1.9.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SharpOnvifServer.Analytics/SharpOnvifServer.Analytics.csproj
+++ b/src/SharpOnvifServer.Analytics/SharpOnvifServer.Analytics.csproj
@@ -16,8 +16,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.XmlSerializer.Generator" Version="$(Microsoft_XmlSerializer_Generator)" />
-		<PackageReference Include="CoreWCF.Http" Version="1.9.0" />
-		<PackageReference Include="CoreWCF.Primitives" Version="1.9.0" />
+		<PackageReference Include="CoreWCF.Http" Version="1.9.1" />
+		<PackageReference Include="CoreWCF.Primitives" Version="1.9.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SharpOnvifServer.AppMgmt/SharpOnvifServer.AppMgmt.csproj
+++ b/src/SharpOnvifServer.AppMgmt/SharpOnvifServer.AppMgmt.csproj
@@ -16,8 +16,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.XmlSerializer.Generator" Version="$(Microsoft_XmlSerializer_Generator)" />
-		<PackageReference Include="CoreWCF.Http" Version="1.9.0" />
-		<PackageReference Include="CoreWCF.Primitives" Version="1.9.0" />
+		<PackageReference Include="CoreWCF.Http" Version="1.9.1" />
+		<PackageReference Include="CoreWCF.Primitives" Version="1.9.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SharpOnvifServer.AuthenticationBehavior/SharpOnvifServer.AuthenticationBehavior.csproj
+++ b/src/SharpOnvifServer.AuthenticationBehavior/SharpOnvifServer.AuthenticationBehavior.csproj
@@ -16,8 +16,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.XmlSerializer.Generator" Version="$(Microsoft_XmlSerializer_Generator)" />
-		<PackageReference Include="CoreWCF.Http" Version="1.9.0" />
-		<PackageReference Include="CoreWCF.Primitives" Version="1.9.0" />
+		<PackageReference Include="CoreWCF.Http" Version="1.9.1" />
+		<PackageReference Include="CoreWCF.Primitives" Version="1.9.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SharpOnvifServer.Credential/SharpOnvifServer.Credential.csproj
+++ b/src/SharpOnvifServer.Credential/SharpOnvifServer.Credential.csproj
@@ -16,8 +16,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.XmlSerializer.Generator" Version="$(Microsoft_XmlSerializer_Generator)" />
-		<PackageReference Include="CoreWCF.Http" Version="1.9.0" />
-		<PackageReference Include="CoreWCF.Primitives" Version="1.9.0" />
+		<PackageReference Include="CoreWCF.Http" Version="1.9.1" />
+		<PackageReference Include="CoreWCF.Primitives" Version="1.9.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SharpOnvifServer.DeviceIO/SharpOnvifServer.DeviceIO.csproj
+++ b/src/SharpOnvifServer.DeviceIO/SharpOnvifServer.DeviceIO.csproj
@@ -16,8 +16,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.XmlSerializer.Generator" Version="$(Microsoft_XmlSerializer_Generator)" />
-		<PackageReference Include="CoreWCF.Http" Version="1.9.0" />
-		<PackageReference Include="CoreWCF.Primitives" Version="1.9.0" />
+		<PackageReference Include="CoreWCF.Http" Version="1.9.1" />
+		<PackageReference Include="CoreWCF.Primitives" Version="1.9.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SharpOnvifServer.DeviceMgmt/SharpOnvifServer.DeviceMgmt.csproj
+++ b/src/SharpOnvifServer.DeviceMgmt/SharpOnvifServer.DeviceMgmt.csproj
@@ -16,8 +16,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.XmlSerializer.Generator" Version="$(Microsoft_XmlSerializer_Generator)" />
-		<PackageReference Include="CoreWCF.Http" Version="1.9.0" />
-		<PackageReference Include="CoreWCF.Primitives" Version="1.9.0" />
+		<PackageReference Include="CoreWCF.Http" Version="1.9.1" />
+		<PackageReference Include="CoreWCF.Primitives" Version="1.9.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SharpOnvifServer.Display/SharpOnvifServer.Display.csproj
+++ b/src/SharpOnvifServer.Display/SharpOnvifServer.Display.csproj
@@ -16,8 +16,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.XmlSerializer.Generator" Version="$(Microsoft_XmlSerializer_Generator)" />
-		<PackageReference Include="CoreWCF.Http" Version="1.9.0" />
-		<PackageReference Include="CoreWCF.Primitives" Version="1.9.0" />
+		<PackageReference Include="CoreWCF.Http" Version="1.9.1" />
+		<PackageReference Include="CoreWCF.Primitives" Version="1.9.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SharpOnvifServer.DoorControl/SharpOnvifServer.DoorControl.csproj
+++ b/src/SharpOnvifServer.DoorControl/SharpOnvifServer.DoorControl.csproj
@@ -16,8 +16,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.XmlSerializer.Generator" Version="$(Microsoft_XmlSerializer_Generator)" />
-		<PackageReference Include="CoreWCF.Http" Version="1.9.0" />
-		<PackageReference Include="CoreWCF.Primitives" Version="1.9.0" />
+		<PackageReference Include="CoreWCF.Http" Version="1.9.1" />
+		<PackageReference Include="CoreWCF.Primitives" Version="1.9.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SharpOnvifServer.Events/SharpOnvifServer.Events.csproj
+++ b/src/SharpOnvifServer.Events/SharpOnvifServer.Events.csproj
@@ -16,8 +16,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.XmlSerializer.Generator" Version="$(Microsoft_XmlSerializer_Generator)" />
-		<PackageReference Include="CoreWCF.Http" Version="1.9.0" />
-		<PackageReference Include="CoreWCF.Primitives" Version="1.9.0" />
+		<PackageReference Include="CoreWCF.Http" Version="1.9.1" />
+		<PackageReference Include="CoreWCF.Primitives" Version="1.9.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SharpOnvifServer.Imaging/SharpOnvifServer.Imaging.csproj
+++ b/src/SharpOnvifServer.Imaging/SharpOnvifServer.Imaging.csproj
@@ -16,8 +16,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.XmlSerializer.Generator" Version="$(Microsoft_XmlSerializer_Generator)" />
-		<PackageReference Include="CoreWCF.Http" Version="1.9.0" />
-		<PackageReference Include="CoreWCF.Primitives" Version="1.9.0" />
+		<PackageReference Include="CoreWCF.Http" Version="1.9.1" />
+		<PackageReference Include="CoreWCF.Primitives" Version="1.9.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SharpOnvifServer.Media/SharpOnvifServer.Media.csproj
+++ b/src/SharpOnvifServer.Media/SharpOnvifServer.Media.csproj
@@ -16,8 +16,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.XmlSerializer.Generator" Version="$(Microsoft_XmlSerializer_Generator)" />
-		<PackageReference Include="CoreWCF.Http" Version="1.9.0" />
-		<PackageReference Include="CoreWCF.Primitives" Version="1.9.0" />
+		<PackageReference Include="CoreWCF.Http" Version="1.9.1" />
+		<PackageReference Include="CoreWCF.Primitives" Version="1.9.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SharpOnvifServer.Media2/SharpOnvifServer.Media2.csproj
+++ b/src/SharpOnvifServer.Media2/SharpOnvifServer.Media2.csproj
@@ -16,8 +16,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.XmlSerializer.Generator" Version="$(Microsoft_XmlSerializer_Generator)" />
-		<PackageReference Include="CoreWCF.Http" Version="1.9.0" />
-		<PackageReference Include="CoreWCF.Primitives" Version="1.9.0" />
+		<PackageReference Include="CoreWCF.Http" Version="1.9.1" />
+		<PackageReference Include="CoreWCF.Primitives" Version="1.9.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SharpOnvifServer.PTZ/SharpOnvifServer.PTZ.csproj
+++ b/src/SharpOnvifServer.PTZ/SharpOnvifServer.PTZ.csproj
@@ -16,8 +16,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.XmlSerializer.Generator" Version="$(Microsoft_XmlSerializer_Generator)" />
-		<PackageReference Include="CoreWCF.Http" Version="1.9.0" />
-		<PackageReference Include="CoreWCF.Primitives" Version="1.9.0" />
+		<PackageReference Include="CoreWCF.Http" Version="1.9.1" />
+		<PackageReference Include="CoreWCF.Primitives" Version="1.9.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SharpOnvifServer.Provisioning/SharpOnvifServer.Provisioning.csproj
+++ b/src/SharpOnvifServer.Provisioning/SharpOnvifServer.Provisioning.csproj
@@ -16,8 +16,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.XmlSerializer.Generator" Version="$(Microsoft_XmlSerializer_Generator)" />
-		<PackageReference Include="CoreWCF.Http" Version="1.9.0" />
-		<PackageReference Include="CoreWCF.Primitives" Version="1.9.0" />
+		<PackageReference Include="CoreWCF.Http" Version="1.9.1" />
+		<PackageReference Include="CoreWCF.Primitives" Version="1.9.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SharpOnvifServer.Receiver/SharpOnvifServer.Receiver.csproj
+++ b/src/SharpOnvifServer.Receiver/SharpOnvifServer.Receiver.csproj
@@ -16,8 +16,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.XmlSerializer.Generator" Version="$(Microsoft_XmlSerializer_Generator)" />
-		<PackageReference Include="CoreWCF.Http" Version="1.9.0" />
-		<PackageReference Include="CoreWCF.Primitives" Version="1.9.0" />
+		<PackageReference Include="CoreWCF.Http" Version="1.9.1" />
+		<PackageReference Include="CoreWCF.Primitives" Version="1.9.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SharpOnvifServer.Recording/SharpOnvifServer.Recording.csproj
+++ b/src/SharpOnvifServer.Recording/SharpOnvifServer.Recording.csproj
@@ -16,8 +16,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.XmlSerializer.Generator" Version="$(Microsoft_XmlSerializer_Generator)" />
-		<PackageReference Include="CoreWCF.Http" Version="1.9.0" />
-		<PackageReference Include="CoreWCF.Primitives" Version="1.9.0" />
+		<PackageReference Include="CoreWCF.Http" Version="1.9.1" />
+		<PackageReference Include="CoreWCF.Primitives" Version="1.9.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SharpOnvifServer.Replay/SharpOnvifServer.Replay.csproj
+++ b/src/SharpOnvifServer.Replay/SharpOnvifServer.Replay.csproj
@@ -16,8 +16,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.XmlSerializer.Generator" Version="$(Microsoft_XmlSerializer_Generator)" />
-		<PackageReference Include="CoreWCF.Http" Version="1.9.0" />
-		<PackageReference Include="CoreWCF.Primitives" Version="1.9.0" />
+		<PackageReference Include="CoreWCF.Http" Version="1.9.1" />
+		<PackageReference Include="CoreWCF.Primitives" Version="1.9.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SharpOnvifServer.Schedule/SharpOnvifServer.Schedule.csproj
+++ b/src/SharpOnvifServer.Schedule/SharpOnvifServer.Schedule.csproj
@@ -16,8 +16,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.XmlSerializer.Generator" Version="$(Microsoft_XmlSerializer_Generator)" />
-		<PackageReference Include="CoreWCF.Http" Version="1.9.0" />
-		<PackageReference Include="CoreWCF.Primitives" Version="1.9.0" />
+		<PackageReference Include="CoreWCF.Http" Version="1.9.1" />
+		<PackageReference Include="CoreWCF.Primitives" Version="1.9.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SharpOnvifServer.Search/SharpOnvifServer.Search.csproj
+++ b/src/SharpOnvifServer.Search/SharpOnvifServer.Search.csproj
@@ -16,8 +16,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.XmlSerializer.Generator" Version="$(Microsoft_XmlSerializer_Generator)" />
-		<PackageReference Include="CoreWCF.Http" Version="1.9.0" />
-		<PackageReference Include="CoreWCF.Primitives" Version="1.9.0" />
+		<PackageReference Include="CoreWCF.Http" Version="1.9.1" />
+		<PackageReference Include="CoreWCF.Primitives" Version="1.9.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SharpOnvifServer.Thermal/SharpOnvifServer.Thermal.csproj
+++ b/src/SharpOnvifServer.Thermal/SharpOnvifServer.Thermal.csproj
@@ -16,8 +16,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.XmlSerializer.Generator" Version="$(Microsoft_XmlSerializer_Generator)" />
-		<PackageReference Include="CoreWCF.Http" Version="1.9.0" />
-		<PackageReference Include="CoreWCF.Primitives" Version="1.9.0" />
+		<PackageReference Include="CoreWCF.Http" Version="1.9.1" />
+		<PackageReference Include="CoreWCF.Primitives" Version="1.9.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SharpOnvifServer.Uplink/SharpOnvifServer.Uplink.csproj
+++ b/src/SharpOnvifServer.Uplink/SharpOnvifServer.Uplink.csproj
@@ -16,8 +16,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.XmlSerializer.Generator" Version="$(Microsoft_XmlSerializer_Generator)" />
-		<PackageReference Include="CoreWCF.Http" Version="1.9.0" />
-		<PackageReference Include="CoreWCF.Primitives" Version="1.9.0" />
+		<PackageReference Include="CoreWCF.Http" Version="1.9.1" />
+		<PackageReference Include="CoreWCF.Primitives" Version="1.9.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SharpOnvifServer/SharpOnvifServer.csproj
+++ b/src/SharpOnvifServer/SharpOnvifServer.csproj
@@ -11,9 +11,9 @@
 	</ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreWCF.Http" Version="1.9.0" />
-    <PackageReference Include="CoreWCF.Primitives" Version="1.9.0" />
-    <PackageReference Include="CoreWCF.WebHttp" Version="1.9.0" />
+    <PackageReference Include="CoreWCF.Http" Version="1.9.1" />
+    <PackageReference Include="CoreWCF.Primitives" Version="1.9.1" />
+    <PackageReference Include="CoreWCF.WebHttp" Version="1.9.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
…le quotes; when using Hikvision cameras, their authentication headers are enclosed in double quotes.

Here is the actual response:

HTTP 请求未经客户端身份验证方案“Anonymous”授权。从服务器收到的身份验证标头为“Digest qop="auth", realm="IP Camera(FN636)", nonce="663338373a34393137373736373ace51538fd6d7317abb7651757a8a65af", stale="FALSE"”。